### PR TITLE
Integrate streaming STT service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Generated data directories and databases
 /data/
 *.db
+__pycache__/
 
 # Go build artifacts
 bin/

--- a/README.md
+++ b/README.md
@@ -54,6 +54,27 @@ An on-disk SQLite event store is created at `event_store.path` (default `./data/
 
 To visualize traces/metrics/logs locally, set `LOQA_TELEMETRY_OTLP_ENDPOINT=localhost:4317` and run the docker-compose stack under `observability/`.
 
+## Speech-to-Text (STT)
+
+Set `stt.enabled: true` in the configuration to activate the streaming STT worker. Two modes are supported:
+
+- `mock` — emits synthetic transcripts, useful for development without a model.
+- `exec` — shells out to a command (for example the bundled `stt/faster_whisper.py` wrapper) that must return JSON `{ "text": "...", "confidence": 0.0 }` on stdout.
+
+Example `stt` configuration:
+
+```yaml
+stt:
+  enabled: true
+  mode: exec
+  command: "python3 stt/faster_whisper.py"
+  model_path: ./models/ggml-base.bin
+  language: en
+  publish_interim: false
+```
+
+> Install dependencies with `pip install faster-whisper` and download an appropriate Whisper model. The helper script caches models between invocations.
+
 ## Architecture
 
 Loqa is designed as a modular, distributed system that can scale across multiple local nodes:

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -32,3 +32,14 @@ event_store:
   retention_days: 30
   max_sessions: 10000
   vacuum_on_start: false
+stt:
+  enabled: false
+  mode: mock
+  command: "python3 stt/faster_whisper.py"
+  model_path: ./models/ggml-base.bin
+  language: en
+  sample_rate: 16000
+  channels: 1
+  frame_duration_ms: 20
+  partial_every_ms: 800
+  publish_interim: false

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,10 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/ggerganov/whisper.cpp/bindings/go v0.0.0-20250919033353-44fa2f647cf2 // indirect
+	github.com/go-audio/audio v1.0.0 // indirect
+	github.com/go-audio/riff v1.0.0 // indirect
+	github.com/go-audio/wav v1.1.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -28,6 +32,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-shellwords v1.0.12 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nats-io/nkeys v0.4.7 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,14 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/ggerganov/whisper.cpp/bindings/go v0.0.0-20250919033353-44fa2f647cf2 h1:5WPnaafnfC0Lnn9UnOb4/mR/Srai/8qC7LT7gGnlGW8=
+github.com/ggerganov/whisper.cpp/bindings/go v0.0.0-20250919033353-44fa2f647cf2/go.mod h1:qyHjS/50ORo01H0NsuEEGsQR9VCtOcEye0gUl2sx1s8=
+github.com/go-audio/audio v1.0.0 h1:zS9vebldgbQqktK4H0lUqWrG8P0NxCJVqcj7ZpNnwd4=
+github.com/go-audio/audio v1.0.0/go.mod h1:6uAu0+H2lHkwdGsAY+j2wHPNPpPoeg5AaEFh9FlA+Zs=
+github.com/go-audio/riff v1.0.0 h1:d8iCGbDvox9BfLagY94fBynxSPHO80LmZCaOsmKxokA=
+github.com/go-audio/riff v1.0.0/go.mod h1:l3cQwc85y79NQFCRB7TiPoNiaijp6q8Z0Uv38rVG498=
+github.com/go-audio/wav v1.1.0 h1:jQgLtbqBzY7G+BM8fXF7AHUk1uHUviWS4X39d5rsL2g=
+github.com/go-audio/wav v1.1.0/go.mod h1:mpe9qfwbScEbkd8uybLuIpTgHyrISw/OTuvjUW2iGtE=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -37,6 +45,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
+github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/nats-io/nats.go v1.37.0 h1:07rauXbVnnJvv1gfIyghFEo6lUcYRY0WXc3x7x0vUxE=

--- a/internal/bus/client.go
+++ b/internal/bus/client.go
@@ -81,3 +81,7 @@ func (c *Client) JetStream() nats.JetStreamContext {
 func (c *Client) Conn() *nats.Conn {
 	return c.conn
 }
+
+func (c *Client) Logger() *slog.Logger {
+	return c.log
+}

--- a/internal/protocol/messages.go
+++ b/internal/protocol/messages.go
@@ -1,0 +1,28 @@
+package protocol
+
+import "time"
+
+// AudioFrame represents PCM audio data streamed from edge devices.
+type AudioFrame struct {
+	SessionID  string `json:"session_id"`
+	Sequence   int    `json:"sequence"`
+	SampleRate int    `json:"sample_rate"`
+	Channels   int    `json:"channels"`
+	PCM        []byte `json:"pcm"`
+	Final      bool   `json:"final"`
+}
+
+// Transcript represents STT output broadcast on the bus.
+type Transcript struct {
+	SessionID  string    `json:"session_id"`
+	Text       string    `json:"text"`
+	Partial    bool      `json:"partial"`
+	Timestamp  time.Time `json:"timestamp"`
+	Confidence float64   `json:"confidence,omitempty"`
+}
+
+const (
+	SubjectAudioFramePrefix  = "audio.frame"
+	SubjectTranscriptPartial = "stt.text.partial"
+	SubjectTranscriptFinal   = "stt.text.final"
+)

--- a/internal/stt/exec_recognizer.go
+++ b/internal/stt/exec_recognizer.go
@@ -1,0 +1,112 @@
+package stt
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"sync"
+
+	"github.com/ambiware-labs/loqa-core/internal/config"
+	"github.com/go-audio/audio"
+	"github.com/go-audio/wav"
+	"github.com/mattn/go-shellwords"
+)
+
+type execRecognizer struct {
+	cmd []string
+	cfg config.STTConfig
+	mu  sync.Mutex
+}
+
+type execResult struct {
+	Text       string  `json:"text"`
+	Confidence float64 `json:"confidence"`
+}
+
+func NewExecRecognizer(cfg config.STTConfig) (Recognizer, error) {
+	parser := shellwords.NewParser()
+	args, err := parser.Parse(cfg.Command)
+	if err != nil {
+		return nil, fmt.Errorf("parse stt command: %w", err)
+	}
+	if len(args) == 0 {
+		return nil, fmt.Errorf("stt command is empty")
+	}
+	return &execRecognizer{cmd: args, cfg: cfg}, nil
+}
+
+func (r *execRecognizer) Transcribe(ctx context.Context, pcm []byte, sampleRate int, channels int, final bool) (TranscriptResult, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	tmpDir := os.TempDir()
+	file, err := os.CreateTemp(tmpDir, "loqa_stt_*.wav")
+	if err != nil {
+		return TranscriptResult{}, fmt.Errorf("temp file: %w", err)
+	}
+	defer os.Remove(file.Name())
+	defer file.Close()
+
+	if err := writePCMToWav(file, pcm, sampleRate, channels); err != nil {
+		return TranscriptResult{}, err
+	}
+
+	args := append([]string{}, r.cmd...)
+	if len(args) == 0 {
+		return TranscriptResult{}, fmt.Errorf("stt command empty")
+	}
+	base := args[0]
+	cmdArgs := args[1:]
+	cmdArgs = append(cmdArgs, "--audio", file.Name())
+	if r.cfg.ModelPath != "" {
+		cmdArgs = append(cmdArgs, "--model", r.cfg.ModelPath)
+	}
+	if r.cfg.Language != "" {
+		cmdArgs = append(cmdArgs, "--language", r.cfg.Language)
+	}
+	if r.cfg.Mode == "exec" && r.cfg.PublishInterim && !final {
+		cmdArgs = append(cmdArgs, "--partial")
+	}
+
+	command := exec.CommandContext(ctx, base, cmdArgs...)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+
+	if err := command.Run(); err != nil {
+		return TranscriptResult{}, fmt.Errorf("stt command failed: %w: %s", err, stderr.String())
+	}
+
+	var resp execResult
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		return TranscriptResult{}, fmt.Errorf("decode stt response: %w", err)
+	}
+	return TranscriptResult{Text: resp.Text, Confidence: resp.Confidence}, nil
+}
+
+func writePCMToWav(file *os.File, pcm []byte, sampleRate int, channels int) error {
+	if len(pcm)%2 != 0 {
+		return fmt.Errorf("pcm payload not aligned")
+	}
+	buffer := &audio.IntBuffer{Format: &audio.Format{NumChannels: channels, SampleRate: sampleRate}}
+	samples := make([]int, len(pcm)/2)
+	for i := 0; i < len(samples); i++ {
+		sample := int(int16(binary.LittleEndian.Uint16(pcm[i*2:])))
+		samples[i] = sample
+	}
+	buffer.Data = samples
+
+	enc := wav.NewEncoder(file, sampleRate, 16, channels, 1)
+	if err := enc.Write(buffer); err != nil {
+		return fmt.Errorf("write wav: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return fmt.Errorf("close wav encoder: %w", err)
+	}
+	return nil
+}

--- a/internal/stt/mock_recognizer.go
+++ b/internal/stt/mock_recognizer.go
@@ -1,0 +1,23 @@
+package stt
+
+import (
+	"context"
+	"fmt"
+)
+
+type mockRecognizer struct{}
+
+func NewMockRecognizer() Recognizer {
+	return &mockRecognizer{}
+}
+
+func (m *mockRecognizer) Transcribe(_ context.Context, pcm []byte, _ int, _ int, final bool) (TranscriptResult, error) {
+	mode := "partial"
+	if final {
+		mode = "final"
+	}
+	return TranscriptResult{
+		Text:       fmt.Sprintf("[%s transcript length=%d]", mode, len(pcm)),
+		Confidence: 0,
+	}, nil
+}

--- a/internal/stt/recognizer.go
+++ b/internal/stt/recognizer.go
@@ -1,0 +1,16 @@
+package stt
+
+import (
+	"context"
+)
+
+// TranscriptResult captures recognizer output.
+type TranscriptResult struct {
+	Text       string
+	Confidence float64
+}
+
+// Recognizer abstracts STT backends.
+type Recognizer interface {
+	Transcribe(ctx context.Context, pcm []byte, sampleRate int, channels int, final bool) (TranscriptResult, error)
+}

--- a/internal/stt/service.go
+++ b/internal/stt/service.go
@@ -1,0 +1,206 @@
+package stt
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/ambiware-labs/loqa-core/internal/bus"
+	"github.com/ambiware-labs/loqa-core/internal/config"
+	"github.com/ambiware-labs/loqa-core/internal/protocol"
+	"github.com/nats-io/nats.go"
+)
+
+type Service struct {
+	cfg        config.STTConfig
+	bus        *bus.Client
+	recognizer Recognizer
+	sessions   map[string]*sessionState
+	mu         sync.Mutex
+	ctx        context.Context
+	cancel     context.CancelFunc
+	sub        *nats.Subscription
+	wg         sync.WaitGroup
+	ready      bool
+}
+
+type sessionState struct {
+	Buffer       []byte
+	LastPartial  time.Time
+	Inflight     bool
+	PendingFinal bool
+}
+
+func NewService(parent context.Context, cfg config.STTConfig, busClient *bus.Client, recognizer Recognizer) *Service {
+	ctx, cancel := context.WithCancel(parent)
+	return &Service{
+		cfg:        cfg,
+		bus:        busClient,
+		recognizer: recognizer,
+		sessions:   make(map[string]*sessionState),
+		ctx:        ctx,
+		cancel:     cancel,
+	}
+}
+
+func (s *Service) Start() error {
+	if !s.cfg.Enabled {
+		return nil
+	}
+	subject := protocol.SubjectAudioFramePrefix + ".>"
+	sub, err := s.bus.Conn().Subscribe(subject, s.handleFrame)
+	if err != nil {
+		return fmt.Errorf("subscribe audio frames: %w", err)
+	}
+	s.sub = sub
+	s.ready = true
+	return nil
+}
+
+func (s *Service) Close() {
+	s.cancel()
+	if s.sub != nil {
+		_ = s.sub.Drain()
+	}
+	s.wg.Wait()
+}
+
+func (s *Service) Healthy() bool {
+	return !s.cfg.Enabled || s.ready
+}
+
+func (s *Service) handleFrame(msg *nats.Msg) {
+	var frame protocol.AudioFrame
+	if err := json.Unmarshal(msg.Data, &frame); err != nil {
+		s.bus.Logger().Warn("failed to decode audio frame", slogError(err))
+		return
+	}
+
+	s.mu.Lock()
+	state := s.sessions[frame.SessionID]
+	if state == nil {
+		state = &sessionState{}
+		s.sessions[frame.SessionID] = state
+	}
+	state.Buffer = append(state.Buffer, frame.PCM...)
+	s.mu.Unlock()
+
+	if s.cfg.PublishInterim && !frame.Final {
+		schedulePartial := s.shouldSchedulePartial(frame.SessionID)
+		if schedulePartial {
+			s.scheduleTranscription(frame.SessionID, false)
+		}
+	}
+	if frame.Final {
+		s.scheduleTranscription(frame.SessionID, true)
+	}
+}
+
+func (s *Service) shouldSchedulePartial(sessionID string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state := s.sessions[sessionID]
+	if state == nil {
+		return false
+	}
+	if state.Inflight {
+		return false
+	}
+	if state.LastPartial.IsZero() {
+		state.LastPartial = time.Now()
+		return true
+	}
+	interval := time.Duration(s.cfg.PartialEveryMS) * time.Millisecond
+	if interval <= 0 {
+		return false
+	}
+	if time.Since(state.LastPartial) >= interval {
+		state.LastPartial = time.Now()
+		return true
+	}
+	return false
+}
+
+func (s *Service) scheduleTranscription(sessionID string, final bool) {
+	s.mu.Lock()
+	state := s.sessions[sessionID]
+	if state == nil {
+		s.mu.Unlock()
+		return
+	}
+	if state.Inflight {
+		if final {
+			state.PendingFinal = true
+		}
+		s.mu.Unlock()
+		return
+	}
+	pcm := append([]byte(nil), state.Buffer...)
+	state.Inflight = true
+	s.mu.Unlock()
+
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		ctx, cancel := context.WithTimeout(s.ctx, 45*time.Second)
+		defer cancel()
+
+		result, err := s.recognizer.Transcribe(ctx, pcm, s.cfg.SampleRate, s.cfg.Channels, final)
+		if err != nil {
+			s.bus.Logger().Warn("stt transcription failed", slogError(err))
+		} else {
+			s.publishTranscript(sessionID, result.Text, result.Confidence, final)
+		}
+
+		s.mu.Lock()
+		state := s.sessions[sessionID]
+		var pendingFinal bool
+		if state != nil {
+			state.Inflight = false
+			pendingFinal = state.PendingFinal
+			if !final {
+				state.LastPartial = time.Now()
+			}
+			if final {
+				delete(s.sessions, sessionID)
+			}
+		}
+		s.mu.Unlock()
+
+		if pendingFinal && !final {
+			s.scheduleTranscription(sessionID, true)
+		}
+	}()
+}
+
+func (s *Service) publishTranscript(sessionID, text string, confidence float64, final bool) {
+	if text == "" {
+		return
+	}
+	subject := protocol.SubjectTranscriptPartial
+	if final {
+		subject = protocol.SubjectTranscriptFinal
+	}
+	msg := protocol.Transcript{
+		SessionID:  sessionID,
+		Text:       text,
+		Partial:    !final,
+		Timestamp:  time.Now().UTC(),
+		Confidence: confidence,
+	}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		s.bus.Logger().Warn("failed to marshal transcript", slogError(err))
+		return
+	}
+	if err := s.bus.Conn().Publish(subject, data); err != nil {
+		s.bus.Logger().Warn("failed to publish transcript", slogError(err))
+	}
+}
+
+func slogError(err error) slog.Attr {
+	return slog.String("error", err.Error())
+}

--- a/observability/docker-compose.yaml
+++ b/observability/docker-compose.yaml
@@ -1,8 +1,6 @@
-version: '3.8'
-
 services:
   prometheus:
-    image: prom/prometheus:v2.56.0
+    image: prom/prometheus:v2.54.1
     restart: unless-stopped
     ports:
       - "9090:9090"

--- a/stt/faster_whisper.py
+++ b/stt/faster_whisper.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Simple CLI wrapper around faster-whisper for Loqa."""
+
+import argparse
+import json
+import sys
+
+try:
+    from faster_whisper import WhisperModel
+except ImportError as exc:  # pragma: no cover - import error messaging
+    print(json.dumps({
+        "error": "faster-whisper not installed",
+        "detail": str(exc),
+    }), file=sys.stderr)
+    sys.exit(2)
+
+
+def build_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Loqa faster-whisper wrapper")
+    parser.add_argument("--model", required=True, help="Path to the Whisper model file")
+    parser.add_argument("--audio", required=True, help="Path to the input WAV file")
+    parser.add_argument("--language", default=None, help="Two-letter language code (optional)")
+    parser.add_argument("--compute-type", default="int8_float16", help="faster-whisper compute type")
+    parser.add_argument("--beam-size", type=int, default=1)
+    parser.add_argument("--temperature", type=float, default=0.0)
+    parser.add_argument("--partial", action="store_true", help="Hint that this request is for an interim transcript")
+    return parser.parse_args()
+
+
+_model_cache = {}
+
+
+def load_model(path: str, compute_type: str) -> WhisperModel:
+    key = (path, compute_type)
+    model = _model_cache.get(key)
+    if model is None:
+        model = WhisperModel(path, device="auto", compute_type=compute_type)
+        _model_cache[key] = model
+    return model
+
+
+def main() -> int:
+    args = build_args()
+    model = load_model(args.model, args.compute_type)
+
+    segments, info = model.transcribe(
+        args.audio,
+        language=args.language,
+        beam_size=args.beam_size,
+        temperature=args.temperature,
+    )
+
+    text = "".join(segment.text for segment in segments).strip()
+    if not text:
+        text = ""
+
+    result = {
+        "text": text,
+    }
+    if info is not None and getattr(info, "avg_logprob", None) is not None:
+        result["confidence"] = float(info.avg_logprob)
+
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add STT configuration (mode, command, model hints) with environment overrides
- introduce STT service listening to `audio.frame.*`, buffering PCM, and publishing transcripts on the bus
- provide exec-backed recognizer (wrapping `stt/faster_whisper.py`) with mock fallback
- wire runtime readiness and shutdown flows; document setup and include example script/config updates

## Testing
- `go test ./...`

Closes #15
