### PR TITLE
Add LLM inference harness with Ollama backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,30 @@ stt:
 
 > Install dependencies with `pip install faster-whisper` and download an appropriate Whisper model. The helper script caches models between invocations.
 
+## LLM Harness
+
+Enable the language model service via `llm.enabled: true`. Two backends are available:
+
+- `mock` – returns placeholder completions.
+- `ollama` – streams completions from a local Ollama server (default endpoint `http://localhost:11434`).
+- `exec` – shells out to a command that reads JSON from stdin and returns `{"content": "..."}` on stdout.
+
+Example Ollama configuration:
+
+```yaml
+llm:
+  enabled: true
+  mode: ollama
+  endpoint: http://localhost:11434
+  model_fast: llama3.2:latest
+  model_balanced: llama3.2:latest
+  default_tier: balanced
+  max_tokens: 256
+  temperature: 0.7
+```
+
+The service subscribes to `nlu.request` messages and publishes streaming completions on `nlu.response.partial`/`nlu.response.final`.
+
 ## Architecture
 
 Loqa is designed as a modular, distributed system that can scale across multiple local nodes:

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -43,3 +43,13 @@ stt:
   frame_duration_ms: 20
   partial_every_ms: 800
   publish_interim: false
+llm:
+  enabled: false
+  mode: mock
+  endpoint: http://localhost:11434
+  command: "ollama run llama3.2"
+  model_fast: llama3.2:latest
+  model_balanced: llama3.2:latest
+  default_tier: balanced
+  max_tokens: 256
+  temperature: 0.7

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -16,6 +16,9 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.STT.Mode != "mock" {
 		t.Fatalf("expected default STT mode mock, got %s", cfg.STT.Mode)
 	}
+	if cfg.LLM.Mode != "mock" {
+		t.Fatalf("expected default LLM mode mock, got %s", cfg.LLM.Mode)
+	}
 }
 
 func TestEnvOverrides(t *testing.T) {
@@ -43,6 +46,14 @@ func TestEnvOverrides(t *testing.T) {
 	t.Setenv("LOQA_STT_FRAME_DURATION_MS", "30")
 	t.Setenv("LOQA_STT_PARTIAL_EVERY_MS", "500")
 	t.Setenv("LOQA_STT_PUBLISH_INTERIM", "true")
+	t.Setenv("LOQA_LLM_ENABLED", "true")
+	t.Setenv("LOQA_LLM_MODE", "ollama")
+	t.Setenv("LOQA_LLM_ENDPOINT", "http://localhost:11434")
+	t.Setenv("LOQA_LLM_MODEL_FAST", "llama3.1:8b")
+	t.Setenv("LOQA_LLM_MODEL_BALANCED", "llama3.1:70b")
+	t.Setenv("LOQA_LLM_DEFAULT_TIER", "fast")
+	t.Setenv("LOQA_LLM_MAX_TOKENS", "128")
+	t.Setenv("LOQA_LLM_TEMPERATURE", "0.5")
 
 	cfg, err := Load("")
 	if err != nil {
@@ -93,5 +104,14 @@ func TestEnvOverrides(t *testing.T) {
 	}
 	if cfg.STT.PartialEveryMS != 500 || !cfg.STT.PublishInterim {
 		t.Fatalf("expected STT partial overrides")
+	}
+	if !cfg.LLM.Enabled || cfg.LLM.Mode != "ollama" {
+		t.Fatalf("expected LLM overrides")
+	}
+	if cfg.LLM.ModelFast != "llama3.1:8b" || cfg.LLM.MaxTokens != 128 {
+		t.Fatalf("expected LLM model/limits override")
+	}
+	if cfg.LLM.Temperature != 0.5 {
+		t.Fatalf("expected LLM temperature override, got %f", cfg.LLM.Temperature)
 	}
 }

--- a/internal/llm/exec.go
+++ b/internal/llm/exec.go
@@ -1,0 +1,75 @@
+package llm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"sync"
+
+	"github.com/mattn/go-shellwords"
+)
+
+type execGenerator struct {
+	cmd []string
+	mu  sync.Mutex
+}
+
+type execResponse struct {
+	Content          string `json:"content"`
+	PromptTokens     int    `json:"prompt_tokens,omitempty"`
+	CompletionTokens int    `json:"completion_tokens,omitempty"`
+}
+
+func NewExecGenerator(command string) (Generator, error) {
+	parser := shellwords.NewParser()
+	args, err := parser.Parse(command)
+	if err != nil {
+		return nil, fmt.Errorf("parse llm command: %w", err)
+	}
+	if len(args) == 0 {
+		return nil, fmt.Errorf("llm command empty")
+	}
+	return &execGenerator{cmd: args}, nil
+}
+
+func (g *execGenerator) Generate(ctx context.Context, req Request, consumer func(Chunk) error) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	payload := map[string]any{
+		"prompt":      req.Prompt,
+		"system":      req.System,
+		"max_tokens":  req.MaxTokens,
+		"temperature": req.Temperature,
+	}
+	input, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	base := g.cmd[0]
+	args := append([]string{}, g.cmd[1:]...)
+	cmd := exec.CommandContext(ctx, base, args...)
+	cmd.Stdin = bytes.NewReader(input)
+	output, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("llm exec command failed: %w", err)
+	}
+
+	var resp execResponse
+	if err := json.Unmarshal(output, &resp); err != nil {
+		return fmt.Errorf("decode llm exec response: %w", err)
+	}
+
+	return consumer(Chunk{
+		SessionID:        req.SessionID,
+		Content:          resp.Content,
+		Partial:          false,
+		PromptTokens:     resp.PromptTokens,
+		CompletionTokens: resp.CompletionTokens,
+		Latency:          0,
+		TraceID:          req.TraceID,
+	})
+}

--- a/internal/llm/mock.go
+++ b/internal/llm/mock.go
@@ -1,0 +1,26 @@
+package llm
+
+import (
+	"context"
+	"strings"
+	"time"
+)
+
+type mockGenerator struct{}
+
+func NewMockGenerator() Generator { return &mockGenerator{} }
+
+func (m *mockGenerator) Generate(ctx context.Context, req Request, consumer func(Chunk) error) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(20 * time.Millisecond):
+	}
+	content := "[mock completion for " + strings.TrimSpace(req.Prompt) + "]"
+	return consumer(Chunk{
+		SessionID: req.SessionID,
+		Content:   content,
+		Partial:   false,
+		Latency:   20 * time.Millisecond,
+	})
+}

--- a/internal/llm/ollama.go
+++ b/internal/llm/ollama.go
@@ -1,0 +1,137 @@
+package llm
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type ollamaGenerator struct {
+	endpoint      string
+	modelFast     string
+	modelBalanced string
+}
+
+func NewOllamaGenerator(endpoint, fastModel, balancedModel string) Generator {
+	return &ollamaGenerator{endpoint: endpoint, modelFast: fastModel, modelBalanced: balancedModel}
+}
+
+func (g *ollamaGenerator) modelForTier(tier string) string {
+	switch tier {
+	case "fast":
+		if g.modelFast != "" {
+			return g.modelFast
+		}
+	case "balanced":
+		if g.modelBalanced != "" {
+			return g.modelBalanced
+		}
+	}
+	if g.modelBalanced != "" {
+		return g.modelBalanced
+	}
+	if g.modelFast != "" {
+		return g.modelFast
+	}
+	return "llama3.2:latest"
+}
+
+type ollamaRequest struct {
+	Model   string        `json:"model"`
+	Prompt  string        `json:"prompt"`
+	System  string        `json:"system,omitempty"`
+	Stream  bool          `json:"stream"`
+	Options ollamaOptions `json:"options"`
+}
+
+type ollamaOptions struct {
+	Temperature float64 `json:"temperature,omitempty"`
+	NumPredict  int     `json:"num_predict,omitempty"`
+}
+
+type ollamaStreamResponse struct {
+	Response        string `json:"response"`
+	Done            bool   `json:"done"`
+	EvalCount       int    `json:"eval_count,omitempty"`
+	PromptEvalCount int    `json:"prompt_eval_count,omitempty"`
+}
+
+func (g *ollamaGenerator) Generate(ctx context.Context, req Request, consumer func(Chunk) error) error {
+	model := g.modelForTier(req.Tier)
+	payload := ollamaRequest{
+		Model:  model,
+		Prompt: req.Prompt,
+		System: req.System,
+		Stream: true,
+		Options: ollamaOptions{
+			Temperature: req.Temperature,
+			NumPredict:  req.MaxTokens,
+		},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	reqCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	httpReq, err := http.NewRequestWithContext(reqCtx, http.MethodPost, g.endpoint+"/api/generate", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("ollama returned status %s", resp.Status)
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	esStart := time.Now()
+	var accumulated string
+	var promptTokens, completionTokens int
+	for scanner.Scan() {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var chunk ollamaStreamResponse
+		if err := json.Unmarshal(line, &chunk); err != nil {
+			return err
+		}
+		accumulated += chunk.Response
+		if chunk.EvalCount > 0 {
+			completionTokens = chunk.EvalCount
+		}
+		if chunk.PromptEvalCount > 0 {
+			promptTokens = chunk.PromptEvalCount
+		}
+		partial := !chunk.Done
+		if err := consumer(Chunk{
+			SessionID:        req.SessionID,
+			Content:          chunk.Response,
+			Partial:          partial,
+			PromptTokens:     promptTokens,
+			CompletionTokens: completionTokens,
+			Latency:          time.Since(esStart),
+			TraceID:          req.TraceID,
+		}); err != nil {
+			return err
+		}
+	}
+	return scanner.Err()
+}

--- a/internal/llm/service.go
+++ b/internal/llm/service.go
@@ -1,0 +1,143 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/ambiware-labs/loqa-core/internal/bus"
+	"github.com/ambiware-labs/loqa-core/internal/config"
+	"github.com/ambiware-labs/loqa-core/internal/protocol"
+	"github.com/nats-io/nats.go"
+)
+
+type Service struct {
+	cfg       config.LLMConfig
+	bus       *bus.Client
+	generator Generator
+	sub       *nats.Subscription
+	ctx       context.Context
+	cancel    context.CancelFunc
+	wg        sync.WaitGroup
+	ready     bool
+	logger    *slog.Logger
+}
+
+func NewService(parent context.Context, cfg config.LLMConfig, busClient *bus.Client, generator Generator, logger *slog.Logger) *Service {
+	ctx, cancel := context.WithCancel(parent)
+	return &Service{
+		cfg:       cfg,
+		bus:       busClient,
+		generator: generator,
+		ctx:       ctx,
+		cancel:    cancel,
+		logger:    logger.With(slog.String("component", "llm-service")),
+	}
+}
+
+func (s *Service) Start() error {
+	if !s.cfg.Enabled {
+		return nil
+	}
+	sub, err := s.bus.Conn().Subscribe(protocol.SubjectLLMRequest, s.handleRequest)
+	if err != nil {
+		return fmt.Errorf("subscribe LLM requests: %w", err)
+	}
+	s.sub = sub
+	s.ready = true
+	return nil
+}
+
+func (s *Service) Close() {
+	s.cancel()
+	if s.sub != nil {
+		_ = s.sub.Drain()
+	}
+	s.wg.Wait()
+}
+
+func (s *Service) Healthy() bool {
+	return !s.cfg.Enabled || s.ready
+}
+
+func (s *Service) handleRequest(msg *nats.Msg) {
+	var req protocol.LLMRequest
+	if err := json.Unmarshal(msg.Data, &req); err != nil {
+		s.logger.Warn("failed to decode llm request", slogError(err))
+		return
+	}
+
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		ctx, cancel := context.WithTimeout(s.ctx, 60*time.Second)
+		defer cancel()
+
+		options, err := OptionsFromConfig(s.cfg, req.Tier)
+		if err != nil {
+			s.logger.Warn("invalid LLM options", slogError(err))
+			return
+		}
+		options.SessionID = req.SessionID
+		options.Prompt = req.Prompt
+		options.System = req.System
+		options.MaxTokens = coalesceInt(req.MaxTokens, s.cfg.MaxTokens)
+		if req.Temperature != 0 {
+			options.Temperature = req.Temperature
+		}
+		options.TraceID = req.TraceID
+
+		start := time.Now()
+		err = s.generator.Generate(ctx, options, func(chunk Chunk) error {
+			return s.publishChunk(chunk)
+		})
+		if err != nil {
+			s.logger.Warn("llm generation failed", slogError(err))
+			return
+		}
+		s.logger.Info("llm generation complete", slog.Duration("latency", time.Since(start)))
+	}()
+}
+
+func (s *Service) publishChunk(chunk Chunk) error {
+	if chunk.Content == "" {
+		return nil
+	}
+	msg := protocol.LLMResponse{
+		SessionID:        chunk.SessionID,
+		Content:          chunk.Content,
+		Partial:          chunk.Partial,
+		TraceID:          chunk.TraceID,
+		PromptTokens:     chunk.PromptTokens,
+		CompletionTokens: chunk.CompletionTokens,
+		LatencyMS:        chunk.Latency.Milliseconds(),
+		Timestamp:        time.Now().UTC(),
+	}
+	subject := protocol.SubjectLLMResponsePartial
+	if !chunk.Partial {
+		subject = protocol.SubjectLLMResponseFinal
+	}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	if err := s.bus.Conn().Publish(subject, data); err != nil {
+		s.logger.Warn("failed to publish llm chunk", slogError(err))
+		return err
+	}
+	return nil
+}
+
+func coalesceInt(value, fallback int) int {
+	if value > 0 {
+		return value
+	}
+	return fallback
+}
+
+func slogError(err error) slog.Attr {
+	return slog.String("error", err.Error())
+}

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -1,0 +1,44 @@
+package llm
+
+import (
+	"context"
+	"time"
+
+	"github.com/ambiware-labs/loqa-core/internal/config"
+)
+
+// Request describes a language model prompt.
+type Request struct {
+	SessionID   string
+	Prompt      string
+	System      string
+	Tier        string
+	MaxTokens   int
+	Temperature float64
+	TraceID     string
+}
+
+// Chunk represents streamed model output.
+type Chunk struct {
+	SessionID        string
+	Content          string
+	Partial          bool
+	PromptTokens     int
+	CompletionTokens int
+	Latency          time.Duration
+	TraceID          string
+}
+
+// Generator defines a pluggable LLM backend.
+type Generator interface {
+	Generate(ctx context.Context, req Request, consumer func(Chunk) error) error
+}
+
+// OptionsFromConfig builds defaults from config.
+func OptionsFromConfig(cfg config.LLMConfig, reqTier string) (Request, error) {
+	req := Request{Tier: cfg.DefaultTier, MaxTokens: cfg.MaxTokens, Temperature: cfg.Temperature}
+	if reqTier != "" {
+		req.Tier = reqTier
+	}
+	return req, nil
+}

--- a/internal/protocol/messages.go
+++ b/internal/protocol/messages.go
@@ -22,7 +22,34 @@ type Transcript struct {
 }
 
 const (
-	SubjectAudioFramePrefix  = "audio.frame"
-	SubjectTranscriptPartial = "stt.text.partial"
-	SubjectTranscriptFinal   = "stt.text.final"
+	SubjectAudioFramePrefix   = "audio.frame"
+	SubjectTranscriptPartial  = "stt.text.partial"
+	SubjectTranscriptFinal    = "stt.text.final"
+	SubjectLLMRequest         = "nlu.request"
+	SubjectLLMResponsePartial = "nlu.response.partial"
+	SubjectLLMResponseFinal   = "nlu.response.final"
 )
+
+// LLMRequest represents a prompt sent to the language model harness.
+type LLMRequest struct {
+	SessionID   string    `json:"session_id"`
+	Prompt      string    `json:"prompt"`
+	System      string    `json:"system,omitempty"`
+	Tier        string    `json:"tier,omitempty"`
+	MaxTokens   int       `json:"max_tokens,omitempty"`
+	Temperature float64   `json:"temperature,omitempty"`
+	TraceID     string    `json:"trace_id,omitempty"`
+	Timestamp   time.Time `json:"timestamp"`
+}
+
+// LLMResponse represents streamed or final completions from the harness.
+type LLMResponse struct {
+	SessionID        string    `json:"session_id"`
+	Content          string    `json:"content"`
+	Partial          bool      `json:"partial"`
+	TraceID          string    `json:"trace_id,omitempty"`
+	PromptTokens     int       `json:"prompt_tokens,omitempty"`
+	CompletionTokens int       `json:"completion_tokens,omitempty"`
+	LatencyMS        int64     `json:"latency_ms,omitempty"`
+	Timestamp        time.Time `json:"timestamp"`
+}


### PR DESCRIPTION
## Summary
- extend runtime configuration with `llm` section and env overrides (mode, endpoint, model tiers)
- implement LLM harness service subscribing to `nlu.request` and streaming responses on `nlu.response.*`
- add pluggable generators: mock, Ollama HTTP streaming, and exec command wrapper
- expose new protocol structs and wire readiness/shutdown handling; update docs and example config

## Testing
- `go test ./...`

Closes #16
