### PR TITLE
Add Kokoro-compatible TTS adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,32 @@ If no config file is supplied the runtime loads defaults and respects the follow
 - `LOQA_EVENT_STORE_RETENTION_DAYS`
 - `LOQA_EVENT_STORE_MAX_SESSIONS`
 - `LOQA_EVENT_STORE_VACUUM_ON_START`
+- `LOQA_STT_ENABLED`
+- `LOQA_STT_MODE`
+- `LOQA_STT_COMMAND`
+- `LOQA_STT_MODEL_PATH`
+- `LOQA_STT_LANGUAGE`
+- `LOQA_STT_SAMPLE_RATE`
+- `LOQA_STT_CHANNELS`
+- `LOQA_STT_FRAME_DURATION_MS`
+- `LOQA_STT_PARTIAL_EVERY_MS`
+- `LOQA_STT_PUBLISH_INTERIM`
+- `LOQA_LLM_ENABLED`
+- `LOQA_LLM_MODE`
+- `LOQA_LLM_ENDPOINT`
+- `LOQA_LLM_COMMAND`
+- `LOQA_LLM_MODEL_FAST`
+- `LOQA_LLM_MODEL_BALANCED`
+- `LOQA_LLM_DEFAULT_TIER`
+- `LOQA_LLM_MAX_TOKENS`
+- `LOQA_LLM_TEMPERATURE`
+- `LOQA_TTS_ENABLED`
+- `LOQA_TTS_MODE`
+- `LOQA_TTS_COMMAND`
+- `LOQA_TTS_VOICE`
+- `LOQA_TTS_SAMPLE_RATE`
+- `LOQA_TTS_CHANNELS`
+- `LOQA_TTS_CHUNK_DURATION_MS`
 
 The bootstrap process exposes `/healthz` and `/readyz` endpoints and initializes OpenTelemetry tracing with a local stdout exporter. See `cmd/loqad --help` for additional flags.
 
@@ -98,6 +124,26 @@ llm:
 ```
 
 The service subscribes to `nlu.request` messages and publishes streaming completions on `nlu.response.partial`/`nlu.response.final`.
+
+## Text-to-Speech (TTS)
+
+Enable with `tts.enabled: true`. Modes:
+
+- `mock` – emits silent audio chunks for development.
+- `exec` – shells out to a command (for example `python3 tts/kokoro_stub.py`) that reads JSON from stdin (`{"text": "hello", "voice": "en-US", "sample_rate": 22050, "channels": 1}`) and writes newline-delimited JSON responses containing base64-encoded PCM buffers (`{"pcm_base64": "...", "final": true}`).
+
+```yaml
+tts:
+  enabled: true
+  mode: exec
+  command: "python3 tts/kokoro_stub.py"
+  voice: en-US
+  sample_rate: 22050
+  channels: 1
+  chunk_duration_ms: 400
+```
+
+Synthesized audio is published on `tts.audio`, with a `tts.done` signal once playback is complete at the originating device.
 
 ## Architecture
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -19,6 +19,9 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.LLM.Mode != "mock" {
 		t.Fatalf("expected default LLM mode mock, got %s", cfg.LLM.Mode)
 	}
+	if cfg.TTS.Mode != "mock" {
+		t.Fatalf("expected default TTS mode mock, got %s", cfg.TTS.Mode)
+	}
 }
 
 func TestEnvOverrides(t *testing.T) {
@@ -54,6 +57,13 @@ func TestEnvOverrides(t *testing.T) {
 	t.Setenv("LOQA_LLM_DEFAULT_TIER", "fast")
 	t.Setenv("LOQA_LLM_MAX_TOKENS", "128")
 	t.Setenv("LOQA_LLM_TEMPERATURE", "0.5")
+	t.Setenv("LOQA_TTS_ENABLED", "true")
+	t.Setenv("LOQA_TTS_MODE", "exec")
+	t.Setenv("LOQA_TTS_COMMAND", "python3 tts/kokoro.py")
+	t.Setenv("LOQA_TTS_VOICE", "en-US")
+	t.Setenv("LOQA_TTS_SAMPLE_RATE", "48000")
+	t.Setenv("LOQA_TTS_CHANNELS", "2")
+	t.Setenv("LOQA_TTS_CHUNK_DURATION_MS", "200")
 
 	cfg, err := Load("")
 	if err != nil {
@@ -113,5 +123,14 @@ func TestEnvOverrides(t *testing.T) {
 	}
 	if cfg.LLM.Temperature != 0.5 {
 		t.Fatalf("expected LLM temperature override, got %f", cfg.LLM.Temperature)
+	}
+	if !cfg.TTS.Enabled || cfg.TTS.Mode != "exec" {
+		t.Fatalf("expected TTS overrides")
+	}
+	if cfg.TTS.SampleRate != 48000 || cfg.TTS.Channels != 2 {
+		t.Fatalf("expected TTS sample overrides")
+	}
+	if cfg.TTS.ChunkDurationMS != 200 {
+		t.Fatalf("expected TTS chunk override")
 	}
 }

--- a/internal/protocol/messages.go
+++ b/internal/protocol/messages.go
@@ -28,6 +28,9 @@ const (
 	SubjectLLMRequest         = "nlu.request"
 	SubjectLLMResponsePartial = "nlu.response.partial"
 	SubjectLLMResponseFinal   = "nlu.response.final"
+	SubjectTTSRequest         = "tts.request"
+	SubjectTTSAudio           = "tts.audio"
+	SubjectTTSDone            = "tts.done"
 )
 
 // LLMRequest represents a prompt sent to the language model harness.
@@ -52,4 +55,31 @@ type LLMResponse struct {
 	CompletionTokens int       `json:"completion_tokens,omitempty"`
 	LatencyMS        int64     `json:"latency_ms,omitempty"`
 	Timestamp        time.Time `json:"timestamp"`
+}
+
+// TTSRequest asks the TTS service to synthesize a phrase.
+type TTSRequest struct {
+	SessionID string `json:"session_id"`
+	Text      string `json:"text"`
+	Voice     string `json:"voice,omitempty"`
+	Target    string `json:"target,omitempty"`
+	TraceID   string `json:"trace_id,omitempty"`
+}
+
+// AudioChunk carries synthesized PCM audio destined for output devices.
+type AudioChunk struct {
+	SessionID  string `json:"session_id"`
+	Target     string `json:"target,omitempty"`
+	Sequence   int    `json:"sequence"`
+	SampleRate int    `json:"sample_rate"`
+	Channels   int    `json:"channels"`
+	PCM        []byte `json:"pcm"`
+	Final      bool   `json:"final"`
+}
+
+type TTSStatus struct {
+	SessionID string    `json:"session_id"`
+	Target    string    `json:"target,omitempty"`
+	Completed bool      `json:"completed"`
+	Timestamp time.Time `json:"timestamp"`
 }

--- a/internal/tts/exec.go
+++ b/internal/tts/exec.go
@@ -1,0 +1,131 @@
+package tts
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"sync"
+
+	"github.com/mattn/go-shellwords"
+)
+
+type execSynth struct {
+	cmd        []string
+	sampleRate int
+	channels   int
+	mu         sync.Mutex
+}
+
+type execRequest struct {
+	Text       string `json:"text"`
+	Voice      string `json:"voice"`
+	SampleRate int    `json:"sample_rate"`
+	Channels   int    `json:"channels"`
+}
+
+type execResponse struct {
+	PCMBase64 string `json:"pcm_base64"`
+	Final     bool   `json:"final"`
+}
+
+func NewExecSynth(command string, sampleRate, channels int) (Synthesizer, error) {
+	parser := shellwords.NewParser()
+	args, err := parser.Parse(command)
+	if err != nil {
+		return nil, fmt.Errorf("parse tts command: %w", err)
+	}
+	if len(args) == 0 {
+		return nil, fmt.Errorf("tts command empty")
+	}
+	return &execSynth{cmd: args, sampleRate: sampleRate, channels: channels}, nil
+}
+
+func (e *execSynth) Synthesize(ctx context.Context, req SynthRequest) (<-chan SynthChunk, <-chan error) {
+	e.mu.Lock()
+	schunks := make(chan SynthChunk)
+	errs := make(chan error, 1)
+	go func() {
+		defer close(schunks)
+		defer close(errs)
+		defer e.mu.Unlock()
+
+		reqPayload := execRequest{
+			Text:       req.Text,
+			Voice:      req.Voice,
+			SampleRate: e.sampleRate,
+			Channels:   e.channels,
+		}
+		data, err := json.Marshal(reqPayload)
+		if err != nil {
+			errs <- err
+			return
+		}
+
+		base := e.cmd[0]
+		args := append([]string{}, e.cmd[1:]...)
+		cmd := exec.CommandContext(ctx, base, args...)
+		stdin, err := cmd.StdinPipe()
+		if err != nil {
+			errs <- err
+			return
+		}
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			errs <- err
+			return
+		}
+		if err := cmd.Start(); err != nil {
+			errs <- err
+			return
+		}
+
+		if _, err := stdin.Write(data); err != nil {
+			errs <- err
+			cmd.Wait()
+			return
+		}
+		stdin.Close()
+
+		scanner := bufio.NewScanner(stdout)
+		sequence := 0
+		for scanner.Scan() {
+			line := scanner.Bytes()
+			if len(line) == 0 {
+				continue
+			}
+			var resp execResponse
+			if err := json.Unmarshal(line, &resp); err != nil {
+				errs <- err
+				cmd.Wait()
+				return
+			}
+			pcm, err := base64.StdEncoding.DecodeString(resp.PCMBase64)
+			if err != nil {
+				errs <- err
+				cmd.Wait()
+				return
+			}
+			schunks <- SynthChunk{
+				SessionID:  req.SessionID,
+				Sequence:   sequence,
+				SampleRate: e.sampleRate,
+				Channels:   e.channels,
+				PCM:        pcm,
+				Final:      resp.Final,
+			}
+			sequence++
+		}
+		err = cmd.Wait()
+		if err != nil {
+			errs <- err
+			return
+		}
+		if scanErr := scanner.Err(); scanErr != nil {
+			errs <- scanErr
+		}
+	}()
+	return schunks, errs
+}

--- a/internal/tts/mock.go
+++ b/internal/tts/mock.go
@@ -1,0 +1,39 @@
+package tts
+
+import (
+	"context"
+	"time"
+)
+
+type mockSynth struct {
+	sampleRate int
+	channels   int
+}
+
+func NewMockSynth(sampleRate, channels int) Synthesizer {
+	return &mockSynth{sampleRate: sampleRate, channels: channels}
+}
+
+func (m *mockSynth) Synthesize(ctx context.Context, req SynthRequest) (<-chan SynthChunk, <-chan error) {
+	chunks := make(chan SynthChunk, 1)
+	errs := make(chan error, 1)
+	go func() {
+		defer close(chunks)
+		defer close(errs)
+		select {
+		case <-ctx.Done():
+			errs <- ctx.Err()
+			return
+		case <-time.After(50 * time.Millisecond):
+		}
+		chunks <- SynthChunk{
+			SessionID:  req.SessionID,
+			Sequence:   0,
+			SampleRate: m.sampleRate,
+			Channels:   m.channels,
+			PCM:        []byte{},
+			Final:      true,
+		}
+	}()
+	return chunks, errs
+}

--- a/internal/tts/service.go
+++ b/internal/tts/service.go
@@ -1,0 +1,132 @@
+package tts
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/ambiware-labs/loqa-core/internal/bus"
+	"github.com/ambiware-labs/loqa-core/internal/config"
+	"github.com/ambiware-labs/loqa-core/internal/protocol"
+	"github.com/nats-io/nats.go"
+)
+
+type Service struct {
+	cfg    config.TTSConfig
+	bus    *bus.Client
+	synth  Synthesizer
+	sub    *nats.Subscription
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+	logger *slog.Logger
+}
+
+func NewService(parent context.Context, cfg config.TTSConfig, busClient *bus.Client, synth Synthesizer, log *slog.Logger) *Service {
+	ctx, cancel := context.WithCancel(parent)
+	return &Service{
+		cfg:    cfg,
+		bus:    busClient,
+		synth:  synth,
+		ctx:    ctx,
+		cancel: cancel,
+		logger: log.With(slog.String("component", "tts-service")),
+	}
+}
+
+func (s *Service) Start() error {
+	if !s.cfg.Enabled {
+		return nil
+	}
+	sub, err := s.bus.Conn().Subscribe(protocol.SubjectTTSRequest, s.handleRequest)
+	if err != nil {
+		return err
+	}
+	s.sub = sub
+	return nil
+}
+
+func (s *Service) Close() {
+	s.cancel()
+	if s.sub != nil {
+		_ = s.sub.Drain()
+	}
+	s.wg.Wait()
+}
+
+func (s *Service) Healthy() bool { return !s.cfg.Enabled || s.sub != nil }
+
+func (s *Service) handleRequest(msg *nats.Msg) {
+	var req protocol.TTSRequest
+	if err := json.Unmarshal(msg.Data, &req); err != nil {
+		s.logger.Warn("failed to decode tts request", slogError(err))
+		return
+	}
+
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+
+		ctx, cancel := context.WithTimeout(s.ctx, 45*time.Second)
+		defer cancel()
+
+		chunks, errs := s.synth.Synthesize(ctx, SynthRequest{SessionID: req.SessionID, Text: req.Text, Voice: req.Voice})
+		sequence := 0
+		for {
+			select {
+			case chunk, ok := <-chunks:
+				if !ok {
+					chunks = nil
+					continue
+				}
+				chunk.Sequence = sequence
+				sequence++
+				s.publishChunk(req, chunk)
+			case err, ok := <-errs:
+				if ok && err != nil {
+					s.logger.Warn("tts synthesis error", slogError(err))
+				}
+				errs = nil
+			case <-ctx.Done():
+				s.logger.Warn("tts synthesis cancelled", slogError(ctx.Err()))
+				return
+			}
+			if chunks == nil && errs == nil {
+				return
+			}
+		}
+	}()
+}
+
+func (s *Service) publishChunk(req protocol.TTSRequest, chunk SynthChunk) {
+	packet := protocol.AudioChunk{
+		SessionID:  req.SessionID,
+		Target:     req.Target,
+		SampleRate: chunk.SampleRate,
+		Channels:   chunk.Channels,
+		Sequence:   chunk.Sequence,
+		PCM:        chunk.PCM,
+		Final:      chunk.Final,
+	}
+	data, err := json.Marshal(packet)
+	if err != nil {
+		s.logger.Warn("failed to marshal tts chunk", slogError(err))
+		return
+	}
+	subject := protocol.SubjectTTSAudio
+	if err := s.bus.Conn().Publish(subject, data); err != nil {
+		s.logger.Warn("failed to publish tts chunk", slogError(err))
+	}
+	if chunk.Final {
+		finalMsg := protocol.TTSStatus{SessionID: req.SessionID, Target: req.Target, Completed: true, Timestamp: time.Now().UTC()}
+		if data, err := json.Marshal(finalMsg); err == nil {
+			_ = s.bus.Conn().Publish(protocol.SubjectTTSDone, data)
+		}
+	}
+}
+
+func slogError(err error) slog.Attr {
+	return slog.String("error", err.Error())
+}

--- a/internal/tts/types.go
+++ b/internal/tts/types.go
@@ -1,0 +1,25 @@
+package tts
+
+import "context"
+
+// SynthRequest contains parameters to synthesize speech.
+type SynthRequest struct {
+	SessionID string
+	Text      string
+	Voice     string
+}
+
+// SynthChunk contains PCM data.
+type SynthChunk struct {
+	SessionID  string
+	Sequence   int
+	SampleRate int
+	Channels   int
+	PCM        []byte
+	Final      bool
+}
+
+// Synthesizer is the contract for producing audio.
+type Synthesizer interface {
+	Synthesize(ctx context.Context, req SynthRequest) (<-chan SynthChunk, <-chan error)
+}

--- a/tts/kokoro_stub.py
+++ b/tts/kokoro_stub.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Stub TTS command for development. Converts text to silence."""
+
+import base64
+import json
+import sys
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError as exc:
+        print(json.dumps({"error": str(exc)}), file=sys.stderr)
+        return 1
+
+    sample_rate = int(payload.get("sample_rate", 22050))
+    channels = int(payload.get("channels", 1))
+    duration_sec = max(0.2, min(1.0, len(payload.get("text", "")) / 50.0))
+    frame_count = int(sample_rate * duration_sec)
+    pcm = bytearray(frame_count * channels * 2)
+
+    resp = {
+        "pcm_base64": base64.b64encode(pcm).decode("ascii"),
+        "final": True,
+    }
+    print(json.dumps(resp))
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- extend configuration with `tts` block (enabled, mode, command, voice, audio settings) and env overrides
- define new protocol messages for `tts.request`, streamed audio chunks, and completion signals
- implement TTS synthesizer service with mock + exec backends and runtime wiring/health gating
- add development stub script (`tts/kokoro_stub.py`) and documentation for running real Kokoro integrations

## Testing
- `go test ./...`

Closes #17
