### PR TITLE
Wire session router over NATS

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ If no config file is supplied the runtime loads defaults and respects the follow
 - `LOQA_TTS_SAMPLE_RATE`
 - `LOQA_TTS_CHANNELS`
 - `LOQA_TTS_CHUNK_DURATION_MS`
+- `LOQA_ROUTER_ENABLED`
+- `LOQA_ROUTER_DEFAULT_TIER`
+- `LOQA_ROUTER_DEFAULT_VOICE`
+- `LOQA_ROUTER_TARGET`
 
 The bootstrap process exposes `/healthz` and `/readyz` endpoints and initializes OpenTelemetry tracing with a local stdout exporter. See `cmd/loqad --help` for additional flags.
 

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -53,3 +53,16 @@ llm:
   default_tier: balanced
   max_tokens: 256
   temperature: 0.7
+tts:
+  enabled: false
+  mode: mock
+  command: "python3 tts/kokoro_stub.py"
+  voice: en-US
+  sample_rate: 22050
+  channels: 1
+  chunk_duration_ms: 400
+router:
+  enabled: true
+  default_tier: balanced
+  default_voice: en-US
+  target: default

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	STT         STTConfig        `yaml:"stt"`
 	LLM         LLMConfig        `yaml:"llm"`
 	TTS         TTSConfig        `yaml:"tts"`
+	Router      RouterConfig     `yaml:"router"`
 }
 
 type BusConfig struct {
@@ -102,6 +103,13 @@ type TTSConfig struct {
 	ChunkDurationMS int    `yaml:"chunk_duration_ms"`
 }
 
+type RouterConfig struct {
+	Enabled      bool   `yaml:"enabled"`
+	DefaultTier  string `yaml:"default_tier"`
+	DefaultVoice string `yaml:"default_voice"`
+	Target       string `yaml:"target"`
+}
+
 func Default() Config {
 	return Config{
 		RuntimeName: "loqa-runtime",
@@ -159,6 +167,12 @@ func Default() Config {
 			SampleRate:      22050,
 			Channels:        1,
 			ChunkDurationMS: 400,
+		},
+		Router: RouterConfig{
+			Enabled:      true,
+			DefaultTier:  "balanced",
+			DefaultVoice: "en-US",
+			Target:       "default",
 		},
 	}
 }
@@ -236,6 +250,10 @@ func applyEnvOverrides(cfg *Config) {
 	overrideInt(&cfg.TTS.SampleRate, "LOQA_TTS_SAMPLE_RATE")
 	overrideInt(&cfg.TTS.Channels, "LOQA_TTS_CHANNELS")
 	overrideInt(&cfg.TTS.ChunkDurationMS, "LOQA_TTS_CHUNK_DURATION_MS")
+	overrideBool(&cfg.Router.Enabled, "LOQA_ROUTER_ENABLED")
+	overrideString(&cfg.Router.DefaultTier, "LOQA_ROUTER_DEFAULT_TIER")
+	overrideString(&cfg.Router.DefaultVoice, "LOQA_ROUTER_DEFAULT_VOICE")
+	overrideString(&cfg.Router.Target, "LOQA_ROUTER_TARGET")
 }
 
 func overrideString(target *string, envKey string) {
@@ -361,6 +379,14 @@ func validate(cfg Config) error {
 		}
 		if cfg.TTS.Channels <= 0 {
 			return errors.New("tts.channels must be positive")
+		}
+	}
+	if cfg.Router.Enabled {
+		if cfg.Router.DefaultTier == "" {
+			cfg.Router.DefaultTier = "balanced"
+		}
+		if cfg.Router.DefaultVoice == "" {
+			cfg.Router.DefaultVoice = "en-US"
 		}
 	}
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -22,6 +22,9 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.TTS.Mode != "mock" {
 		t.Fatalf("expected default TTS mode mock, got %s", cfg.TTS.Mode)
 	}
+	if !cfg.Router.Enabled {
+		t.Fatalf("expected router enabled by default")
+	}
 }
 
 func TestEnvOverrides(t *testing.T) {
@@ -64,6 +67,10 @@ func TestEnvOverrides(t *testing.T) {
 	t.Setenv("LOQA_TTS_SAMPLE_RATE", "48000")
 	t.Setenv("LOQA_TTS_CHANNELS", "2")
 	t.Setenv("LOQA_TTS_CHUNK_DURATION_MS", "200")
+	t.Setenv("LOQA_ROUTER_ENABLED", "true")
+	t.Setenv("LOQA_ROUTER_DEFAULT_TIER", "fast")
+	t.Setenv("LOQA_ROUTER_DEFAULT_VOICE", "en-GB")
+	t.Setenv("LOQA_ROUTER_TARGET", "livingroom")
 
 	cfg, err := Load("")
 	if err != nil {
@@ -132,5 +139,8 @@ func TestEnvOverrides(t *testing.T) {
 	}
 	if cfg.TTS.ChunkDurationMS != 200 {
 		t.Fatalf("expected TTS chunk override")
+	}
+	if !cfg.Router.Enabled || cfg.Router.DefaultTier != "fast" || cfg.Router.DefaultVoice != "en-GB" || cfg.Router.Target != "livingroom" {
+		t.Fatalf("expected router overrides")
 	}
 }

--- a/internal/router/service.go
+++ b/internal/router/service.go
@@ -1,0 +1,167 @@
+package router
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/ambiware-labs/loqa-core/internal/bus"
+	"github.com/ambiware-labs/loqa-core/internal/config"
+	"github.com/ambiware-labs/loqa-core/internal/protocol"
+	"github.com/nats-io/nats.go"
+)
+
+type Service struct {
+	cfg            config.RouterConfig
+	bus            *bus.Client
+	logger         *slog.Logger
+	subTranscripts *nats.Subscription
+	subLLM         *nats.Subscription
+	ctx            context.Context
+	cancel         context.CancelFunc
+	wg             sync.WaitGroup
+	sessions       map[string]*sessionState
+	mu             sync.Mutex
+}
+
+type sessionState struct {
+	LastPrompt string
+	Voice      string
+	Tier       string
+}
+
+func NewService(parent context.Context, cfg config.RouterConfig, busClient *bus.Client, logger *slog.Logger) *Service {
+	ctx, cancel := context.WithCancel(parent)
+	return &Service{
+		cfg:      cfg,
+		bus:      busClient,
+		logger:   logger.With(slog.String("component", "router")),
+		ctx:      ctx,
+		cancel:   cancel,
+		sessions: make(map[string]*sessionState),
+	}
+}
+
+func (s *Service) Start() error {
+	if !s.cfg.Enabled {
+		return nil
+	}
+	sub, err := s.bus.Conn().Subscribe(protocol.SubjectTranscriptFinal, s.handleTranscript)
+	if err != nil {
+		return err
+	}
+	s.subTranscripts = sub
+
+	subLLM, err := s.bus.Conn().Subscribe(protocol.SubjectLLMResponseFinal, s.handleLLMResponse)
+	if err != nil {
+		s.subTranscripts.Drain()
+		return err
+	}
+	s.subLLM = subLLM
+	return nil
+}
+
+func (s *Service) Close() {
+	s.cancel()
+	if s.subTranscripts != nil {
+		_ = s.subTranscripts.Drain()
+	}
+	if s.subLLM != nil {
+		_ = s.subLLM.Drain()
+	}
+	s.wg.Wait()
+}
+
+func (s *Service) Healthy() bool {
+	return !s.cfg.Enabled || (s.subTranscripts != nil && s.subLLM != nil)
+}
+
+func (s *Service) handleTranscript(msg *nats.Msg) {
+	var transcript protocol.Transcript
+	if err := json.Unmarshal(msg.Data, &transcript); err != nil {
+		s.logger.Warn("router failed to decode transcript", slogError(err))
+		return
+	}
+	prompt := transcript.Text
+	if prompt == "" {
+		return
+	}
+
+	s.mu.Lock()
+	s.sessions[transcript.SessionID] = &sessionState{
+		LastPrompt: prompt,
+		Voice:      s.cfg.DefaultVoice,
+		Tier:       s.cfg.DefaultTier,
+	}
+	s.mu.Unlock()
+
+	req := protocol.LLMRequest{
+		SessionID: transcript.SessionID,
+		Prompt:    prompt,
+		Tier:      s.cfg.DefaultTier,
+		Timestamp: time.Now().UTC(),
+	}
+	if err := s.publishLLMRequest(req); err != nil {
+		s.logger.Warn("router failed to publish llm request", slogError(err))
+	}
+}
+
+func (s *Service) publishLLMRequest(req protocol.LLMRequest) error {
+	data, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+	return s.bus.Conn().Publish(protocol.SubjectLLMRequest, data)
+}
+
+func (s *Service) handleLLMResponse(msg *nats.Msg) {
+	var resp protocol.LLMResponse
+	if err := json.Unmarshal(msg.Data, &resp); err != nil {
+		s.logger.Warn("router failed to decode llm response", slogError(err))
+		return
+	}
+	if resp.Content == "" {
+		return
+	}
+
+	s.mu.Lock()
+	state := s.sessions[resp.SessionID]
+	if state != nil {
+		delete(s.sessions, resp.SessionID)
+	}
+	s.mu.Unlock()
+
+	voice := s.cfg.DefaultVoice
+	if state != nil && state.Voice != "" {
+		voice = state.Voice
+	}
+
+	req := protocol.TTSRequest{
+		SessionID: resp.SessionID,
+		Text:      resp.Content,
+		Voice:     voice,
+		Target:    s.cfg.Target,
+		TraceID:   resp.TraceID,
+	}
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		if err := s.publishTTSRequest(req); err != nil {
+			s.logger.Warn("router failed to publish tts request", slogError(err))
+		}
+	}()
+}
+
+func (s *Service) publishTTSRequest(req protocol.TTSRequest) error {
+	data, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+	return s.bus.Conn().Publish(protocol.SubjectTTSRequest, data)
+}
+
+func slogError(err error) slog.Attr {
+	return slog.String("error", err.Error())
+}


### PR DESCRIPTION
## Summary
- add router configuration (enable flag, default tier/voice/target) with env overrides
- define protocol messages for `tts.request`, streamed audio chunks, and completion signals
- implement router service that consumes STT transcripts, publishes LLM requests, and dispatches TTS requests on final LLM responses
- hook the router into runtime lifecycle and readiness checks; document configuration defaults

## Testing
- `go test ./...`

Closes #18
