### PR TITLE
Add skill manifest schema and validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,14 @@ tts:
 
 Synthesized audio is published on `tts.audio`, with a `tts.done` signal once playback is complete at the originating device.
 
+## Skills
+
+Skill packages declare metadata, runtime, and permissions in a `skill.yaml` manifest. Validate locally with:
+
+```bash
+go run ./cmd/loqa-skill validate --file skills/examples/timer/skill.yaml
+```
+
 ## Architecture
 
 Loqa is designed as a modular, distributed system that can scale across multiple local nodes:

--- a/cmd/loqa-skill/main.go
+++ b/cmd/loqa-skill/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+    "flag"
+    "fmt"
+    "os"
+
+    "github.com/ambiware-labs/loqa-core/internal/skills/manifest"
+)
+
+func main() {
+    var manifestPath string
+    validateCmd := flag.NewFlagSet("validate", flag.ExitOnError)
+    validateCmd.StringVar(&manifestPath, "file", "skill.yaml", "Path to skill manifest")
+
+    if len(os.Args) < 2 {
+        fmt.Fprintln(os.Stderr, "expected 'validate'")
+        os.Exit(2)
+    }
+
+    switch os.Args[1] {
+    case "validate":
+        validateCmd.Parse(os.Args[2:])
+        if err := runValidate(manifestPath); err != nil {
+            fmt.Fprintln(os.Stderr, err)
+            os.Exit(1)
+        }
+        fmt.Println("manifest valid")
+    default:
+        fmt.Fprintf(os.Stderr, "unknown command %q\n", os.Args[1])
+        os.Exit(2)
+    }
+}
+
+func runValidate(path string) error {
+    m, err := manifest.Load(path)
+    if err != nil {
+        return err
+    }
+    return manifest.Validate(m)
+}

--- a/internal/skills/manifest/manifest.go
+++ b/internal/skills/manifest/manifest.go
@@ -1,0 +1,97 @@
+package manifest
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Manifest describes a Loqa skill package.
+type Manifest struct {
+	Metadata     Metadata     `yaml:"metadata"`
+	Runtime      RuntimeSpec  `yaml:"runtime"`
+	Capabilities Capabilities `yaml:"capabilities"`
+	Permissions  []string     `yaml:"permissions"`
+	Surfaces     Surfaces     `yaml:"surfaces,omitempty"`
+}
+
+type Metadata struct {
+	Name        string   `yaml:"name"`
+	Version     string   `yaml:"version"`
+	Description string   `yaml:"description"`
+	Author      string   `yaml:"author"`
+	Tags        []string `yaml:"tags,omitempty"`
+}
+
+type RuntimeSpec struct {
+	Mode        string `yaml:"mode"`
+	Module      string `yaml:"module"`
+	Entrypoint  string `yaml:"entrypoint"`
+	HostVersion string `yaml:"host_version"`
+}
+
+type Capabilities struct {
+	Bus     BusSpec     `yaml:"bus"`
+	Storage StorageSpec `yaml:"storage,omitempty"`
+	Timers  bool        `yaml:"timers,omitempty"`
+}
+
+type BusSpec struct {
+	Publish   []string `yaml:"publish,omitempty"`
+	Subscribe []string `yaml:"subscribe,omitempty"`
+}
+
+type StorageSpec struct {
+	KV bool `yaml:"kv"`
+}
+
+type Surfaces struct {
+	Voice       bool `yaml:"voice,omitempty"`
+	Display     bool `yaml:"display,omitempty"`
+	Automations bool `yaml:"automations,omitempty"`
+}
+
+// Load reads a manifest from disk.
+func Load(path string) (Manifest, error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return Manifest{}, err
+	}
+	var m Manifest
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return Manifest{}, err
+	}
+	return m, nil
+}
+
+// Validate ensures manifest contains required fields.
+func Validate(m Manifest) error {
+	if m.Metadata.Name == "" {
+		return fmt.Errorf("metadata.name is required")
+	}
+	if m.Metadata.Version == "" {
+		return fmt.Errorf("metadata.version is required")
+	}
+	if m.Runtime.Mode == "" {
+		return fmt.Errorf("runtime.mode is required")
+	}
+	switch m.Runtime.Mode {
+	case "wasm":
+		if m.Runtime.Module == "" {
+			return fmt.Errorf("runtime.module is required for wasm")
+		}
+		if m.Runtime.Entrypoint == "" {
+			return fmt.Errorf("runtime.entrypoint is required for wasm")
+		}
+	default:
+		return fmt.Errorf("runtime.mode %q not supported", m.Runtime.Mode)
+	}
+	if len(m.Capabilities.Bus.Publish) == 0 && len(m.Capabilities.Bus.Subscribe) == 0 {
+		return fmt.Errorf("capabilities.bus must declare publish or subscribe subjects")
+	}
+	if len(m.Permissions) == 0 {
+		return fmt.Errorf("permissions must include at least one entry")
+	}
+	return nil
+}

--- a/internal/skills/manifest/manifest_test.go
+++ b/internal/skills/manifest/manifest_test.go
@@ -1,0 +1,67 @@
+package manifest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const validYAML = `metadata:
+  name: timer
+  version: 0.1.0
+  description: Timer skill
+  author: Ambiware Labs
+runtime:
+  mode: wasm
+  module: build/timer.wasm
+  entrypoint: handle
+  host_version: v1
+capabilities:
+  bus:
+    publish:
+      - tts.request
+    subscribe:
+      - skill.timer.input
+  storage:
+    kv: true
+  timers: true
+permissions:
+  - event_store:read
+surfaces:
+  voice: true
+`
+
+func TestValidateValidManifest(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "skill.yaml")
+	if err := os.WriteFile(path, []byte(validYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if err := Validate(m); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+}
+
+func TestValidateMissingFields(t *testing.T) {
+	m := Manifest{}
+	if err := Validate(m); err == nil {
+		t.Fatalf("expected validation error")
+	}
+}
+
+func TestValidateUnsupportedMode(t *testing.T) {
+	m := Manifest{
+		Metadata:     Metadata{Name: "x", Version: "1"},
+		Runtime:      RuntimeSpec{Mode: "python"},
+		Capabilities: Capabilities{Bus: BusSpec{Publish: []string{"foo"}}},
+		Permissions:  []string{"foo"},
+	}
+	if err := Validate(m); err == nil {
+		t.Fatalf("expected error for unsupported runtime")
+	}
+}

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,9 @@
+# Skill Examples
+
+Sample manifests live under `skills/examples`. Validate a manifest with:
+
+```bash
+go run ./cmd/loqa-skill validate --file skills/examples/timer/skill.yaml
+```
+
+The validation command ensures required metadata, runtime mode, and permissions are present before loading a skill into Loqa.

--- a/skills/examples/timer/skill.yaml
+++ b/skills/examples/timer/skill.yaml
@@ -1,0 +1,25 @@
+metadata:
+  name: timer
+  version: 0.1.0
+  description: Basic timer skill
+  author: Ambiware Labs
+  tags:
+    - timers
+runtime:
+  mode: wasm
+  module: build/timer.wasm
+  entrypoint: handle
+  host_version: v1
+capabilities:
+  bus:
+    publish:
+      - tts.request
+    subscribe:
+      - skill.timer.start
+  storage:
+    kv: true
+  timers: true
+permissions:
+  - event_store:read
+surfaces:
+  voice: true


### PR DESCRIPTION
## Summary
- introduce `internal/skills/manifest` package with YAML schema structs, loader, and validation logic
- add `cmd/loqa-skill` CLI (`validate` subcommand) for checking manifests locally
- include example manifest (`skills/examples/timer/skill.yaml`) and README instructions
- document skill validation command in project README

## Testing
- `go test ./...`

Closes #25
