### PR TITLE
Add WASM skill runtime skeleton

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/prometheus/otlptranslator v0.0.2 // indirect
 	github.com/prometheus/procfs v0.17.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	github.com/tetratelabs/wazero v1.7.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.38.0 // indirect
 	go.opentelemetry.io/otel/trace v1.38.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tetratelabs/wazero v1.7.0 h1:jg5qPydno59wqjpGrHph81lbtHzTrWzwwtD4cD88+hQ=
+github.com/tetratelabs/wazero v1.7.0/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/otel v1.38.0 h1:RkfdswUDRimDg0m2Az18RKOsnI8UDzppJAtj01/Ymk8=

--- a/internal/skills/runtime/runtime.go
+++ b/internal/skills/runtime/runtime.go
@@ -1,0 +1,104 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/ambiware-labs/loqa-core/internal/skills/manifest"
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
+)
+
+// Runtime wraps a wazero runtime for executing skill modules.
+type Runtime struct {
+	rt wazero.Runtime
+}
+
+// New creates a new skill runtime using wazero.
+func New(ctx context.Context) (*Runtime, error) {
+	rt := wazero.NewRuntime(ctx)
+	if _, err := wasi_snapshot_preview1.Instantiate(ctx, rt); err != nil {
+		return nil, fmt.Errorf("instantiate WASI: %w", err)
+	}
+	return &Runtime{rt: rt}, nil
+}
+
+// Close releases resources held by the runtime.
+func (r *Runtime) Close(ctx context.Context) error {
+	if r == nil || r.rt == nil {
+		return nil
+	}
+	return r.rt.Close(ctx)
+}
+
+// Skill represents a loaded skill module.
+type Skill struct {
+	Manifest manifest.Manifest
+	module   api.Module
+	entry    api.Function
+	compiled wazero.CompiledModule
+}
+
+// Close releases resources for the skill.
+func (s *Skill) Close(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	if s.module != nil {
+		if err := s.module.Close(ctx); err != nil {
+			return err
+		}
+	}
+	if s.compiled != nil {
+		if err := s.compiled.Close(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Load compiles and instantiates a skill from a manifest.
+func (r *Runtime) Load(ctx context.Context, m manifest.Manifest) (*Skill, error) {
+	if r == nil || r.rt == nil {
+		return nil, fmt.Errorf("runtime not initialized")
+	}
+	if m.Runtime.Mode != "wasm" {
+		return nil, fmt.Errorf("unsupported runtime mode %q", m.Runtime.Mode)
+	}
+	wasmBytes, err := os.ReadFile(m.Runtime.Module)
+	if err != nil {
+		return nil, fmt.Errorf("read wasm module: %w", err)
+	}
+	compiled, err := r.rt.CompileModule(ctx, wasmBytes)
+	if err != nil {
+		return nil, fmt.Errorf("compile module: %w", err)
+	}
+	module, err := r.rt.InstantiateModule(ctx, compiled, wazero.NewModuleConfig())
+	if err != nil {
+		compiled.Close(ctx)
+		return nil, fmt.Errorf("instantiate module: %w", err)
+	}
+	entry := module.ExportedFunction(m.Runtime.Entrypoint)
+	if entry == nil {
+		module.Close(ctx)
+		compiled.Close(ctx)
+		return nil, fmt.Errorf("entrypoint %q not found", m.Runtime.Entrypoint)
+	}
+	return &Skill{
+		Manifest: m,
+		module:   module,
+		entry:    entry,
+		compiled: compiled,
+	}, nil
+}
+
+// Invoke executes the skill entrypoint. Currently no parameters are passed.
+func (s *Skill) Invoke(ctx context.Context) error {
+	if s == nil || s.entry == nil {
+		return fmt.Errorf("skill entrypoint not available")
+	}
+	_, err := s.entry.Call(ctx)
+	return err
+}

--- a/internal/skills/runtime/runtime_test.go
+++ b/internal/skills/runtime/runtime_test.go
@@ -1,0 +1,58 @@
+package runtime_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ambiware-labs/loqa-core/internal/skills/manifest"
+	runtime "github.com/ambiware-labs/loqa-core/internal/skills/runtime"
+)
+
+const sampleManifest = `metadata:
+  name: sample
+  version: 0.0.1
+  description: example skill
+  author: test
+runtime:
+  mode: wasm
+  module: %s
+  entrypoint: run
+  host_version: v1
+capabilities:
+  bus:
+    publish:
+      - sample.output
+permissions:
+  - bus:use
+`
+
+func TestRuntimeLoadMissingFile(t *testing.T) {
+	ctx := context.Background()
+	rt, err := runtime.New(ctx)
+	if err != nil {
+		t.Fatalf("create runtime: %v", err)
+	}
+	t.Cleanup(func() { rt.Close(ctx) })
+
+	mfYAML := []byte(formatManifest(sampleManifest, filepath.Join(t.TempDir(), "missing.wasm")))
+	manifestPath := filepath.Join(t.TempDir(), "manifest.yaml")
+	if err := os.WriteFile(manifestPath, mfYAML, 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	mf, err := manifest.Load(manifestPath)
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+
+	if _, err := rt.Load(ctx, mf); err == nil {
+		t.Fatalf("expected error for missing module")
+	}
+}
+
+func formatManifest(template, modulePath string) string {
+	return fmt.Sprintf(template, modulePath)
+}


### PR DESCRIPTION
## Summary
- introduce `internal/skills/runtime` package wrapping wazero with a simple `Load`/`Invoke` API
- wire up WASI support and provide managed cleanup for compiled modules
- add a regression test covering manifest load failure for missing modules
- vendor wazero dependency updates via go.mod/go.sum

## Testing
- `go test ./...`

Closes #26
