### PR TITLE
Add reference skills examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,47 @@ on:
     branches: ["main"]
 
 jobs:
-  placeholder:
+  skills-examples:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: CI placeholder
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22.x"
+
+      - name: Set up TinyGo
+        uses: acifani/setup-tinygo@v2
+        with:
+          tinygo-version: "0.39.0"
+
+      - name: Verify toolchains
         run: |
-          echo "CI pipeline scaffolding in place."
-          echo "Replace this step with real build/test jobs as the codebase matures."
+          go version
+          tinygo version
+          tinygo env GOVERSION
+
+      - name: Build timer skill
+        run: |
+          cd skills/examples/timer
+          mkdir -p build
+          tinygo build -o build/timer.wasm -target=wasi ./src
+
+      - name: Validate timer manifest
+        run: |
+          go run ./cmd/loqa-skill validate --file skills/examples/timer/skill.yaml
+
+      - name: Build smart-home bridge skill
+        run: |
+          cd skills/examples/smart-home
+          mkdir -p build
+          tinygo build -o build/smart-home.wasm -target=wasi ./src
+
+      - name: Validate smart-home manifest
+        run: |
+          go run ./cmd/loqa-skill validate --file skills/examples/smart-home/skill.yaml
+
+      - name: Go unit tests
+        run: go test ./...

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ __pycache__/
 # Go build artifacts
 bin/
 go-build/
+
+# Skill example build outputs
+skills/examples/*/build/

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,9 +1,41 @@
-# Skill Examples
+# Skills
 
-Sample manifests live under `skills/examples`. Validate a manifest with:
+Loqa skills are packaged as WASM modules accompanied by a `skill.yaml` manifest that advertises metadata, runtime configuration, capabilities, and permissions. The examples in `skills/examples` act as reference implementations and regression fixtures for the host runtime.
+
+## Prerequisites
+
+- Go toolchain for running the manifest validator (`go run ./cmd/loqa-skill ...`).
+- [TinyGo](https://tinygo.org/) `0.39+` to compile the WASM modules targeting WASI.
+- (Optional) A WASI runtime such as `wasmtime` if you want to execute the modules in isolation.
+
+## Build workflow
+
+Each example ships with TinyGo sources under `src/` and a `skill.yaml` manifest. Compile and validate with:
 
 ```bash
-go run ./cmd/loqa-skill validate --file skills/examples/timer/skill.yaml
+cd skills/examples/timer
+mkdir -p build
+tinygo build -o build/timer.wasm -target=wasi ./src
+
+go run ./cmd/loqa-skill validate --file skill.yaml
 ```
 
-The validation command ensures required metadata, runtime mode, and permissions are present before loading a skill into Loqa.
+Repeat the same steps for other examples like `smart-home`.
+
+> CI note: The GitHub Actions workflow automatically builds these references with TinyGo and validates each `skill.yaml`, so keep the manifests and TinyGo sources in sync with your changes.
+
+## Local testing
+
+Both examples accept environment variables so you can simulate inbound events before integrating with Loqa:
+
+- `LOQA_TIMER_REQUEST` drives the timer countdown example.
+- `LOQA_SMART_HOME_INTENT` plus optional Home Assistant credentials drive the smart-home bridge.
+
+See the README inside each example directory for precise commands.
+
+## Deploying skills into Loqa
+
+1. Copy the compiled WASM binaries and manifests into the runtime's skill directory.
+2. Ensure the runtime has been granted the permissions declared in the manifest.
+3. Restart or hot-reload the runtime so the new skills are discovered.
+4. Publish the subjects listed under `capabilities.bus` to exercise the skills once the host wiring is complete.

--- a/skills/examples/internal/host/host.go
+++ b/skills/examples/internal/host/host.go
@@ -1,0 +1,17 @@
+//go:build tinygo || wasm
+
+package host
+
+import "unsafe"
+
+// Log forwards text to the host runtime via the imported host_log function.
+func Log(msg string) {
+	if len(msg) == 0 {
+		return
+	}
+	b := []byte(msg)
+	hostLog(unsafe.Pointer(&b[0]), uint32(len(b)))
+}
+
+//go:wasmimport env host_log
+func hostLog(ptr unsafe.Pointer, length uint32)

--- a/skills/examples/internal/host/host_stub.go
+++ b/skills/examples/internal/host/host_stub.go
@@ -1,0 +1,6 @@
+//go:build !tinygo && !wasm
+
+package host
+
+// Log is a no-op stub for non-wasm builds so that `go test` succeeds.
+func Log(string) {}

--- a/skills/examples/smart-home/README.md
+++ b/skills/examples/smart-home/README.md
@@ -1,0 +1,34 @@
+# Smart Home Bridge Skill
+
+Mock bridge that demonstrates how a WASM skill could forward intents to a Home Assistant deployment. The manifest highlights required message subjects, persistent storage, and host permissions for outbound HTTP requests.
+
+## Build (TinyGo)
+
+```bash
+cd skills/examples/smart-home
+mkdir -p build
+tinygo build -o build/smart-home.wasm -target=wasi ./src
+```
+
+## Local smoke test
+
+The module reads configuration from environment variables so you can experiment without a Loqa host:
+
+```bash
+wasmtime run \
+  --env HOMEASSISTANT_URL="http://localhost:8123" \
+  --env HOMEASSISTANT_TOKEN="demo-token" \
+  --env LOQA_SMART_HOME_INTENT='{"room":"kitchen","device":"light.kitchen","action":"turn_on","payload":"brightness=80"}' \
+  build/smart-home.wasm
+```
+
+It does not perform real HTTP calls yet; instead it logs the request that would be sent via the host runtime.
+
+## Deploying into Loqa
+
+1. Validate the manifest:
+   ```bash
+   go run ./cmd/loqa-skill validate --file skill.yaml
+   ```
+2. Copy both `skill.yaml` and `build/smart-home.wasm` into the configured skills directory.
+3. Ensure the runtime grants the `http:call`, `bus:publish`, and `bus:subscribe` permissions defined in the manifest.

--- a/skills/examples/smart-home/skill.yaml
+++ b/skills/examples/smart-home/skill.yaml
@@ -1,0 +1,25 @@
+metadata:
+  name: smart-home-bridge
+  version: 0.1.0
+  description: Bridges Loqa intents to a local Home Assistant instance.
+  author: Ambiware Labs
+runtime:
+  mode: wasm
+  module: build/smart-home.wasm
+  entrypoint: run
+  host_version: v1
+capabilities:
+  bus:
+    subscribe:
+      - skill.home.command
+    publish:
+      - skill.home.status
+  storage:
+    kv: true
+permissions:
+  - http:call
+  - bus:publish
+  - bus:subscribe
+surfaces:
+  voice: true
+  automations: true

--- a/skills/examples/smart-home/src/main.go
+++ b/skills/examples/smart-home/src/main.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/ambiware-labs/loqa-core/skills/examples/internal/host"
+)
+
+type intent struct {
+	Room    string `json:"room"`
+	Device  string `json:"device"`
+	Action  string `json:"action"`
+	Payload string `json:"payload"`
+}
+
+//export run
+func run() {
+	host.Log("smart-home bridge skill initialized")
+
+	endpoint := os.Getenv("HOMEASSISTANT_URL")
+	if endpoint == "" {
+		host.Log("HOMEASSISTANT_URL not set; using http://localhost:8123")
+		endpoint = "http://localhost:8123"
+	}
+
+	token := os.Getenv("HOMEASSISTANT_TOKEN")
+	if token == "" {
+		host.Log("HOMEASSISTANT_TOKEN not provided; requests will fail against a real instance")
+	}
+
+	payload := os.Getenv("LOQA_SMART_HOME_INTENT")
+	if payload == "" {
+		host.Log("no intent supplied; set LOQA_SMART_HOME_INTENT to test locally")
+		return
+	}
+
+	var cmd intent
+	if err := json.Unmarshal([]byte(payload), &cmd); err != nil {
+		host.Log("failed to parse intent: " + err.Error())
+		return
+	}
+
+	if cmd.Action == "" || cmd.Device == "" {
+		host.Log("intent missing required fields: action/device")
+		return
+	}
+
+	body, err := json.Marshal(map[string]string{
+		"entity_id": cmd.Device,
+		"room":      cmd.Room,
+		"payload":   cmd.Payload,
+	})
+	if err != nil {
+		host.Log("failed to encode outbound payload: " + err.Error())
+		return
+	}
+
+	host.Log("would call Home Assistant at " + endpoint)
+	host.Log("authorization token present: " + boolText(token != ""))
+	host.Log("request body: " + string(body))
+}
+
+func boolText(v bool) string {
+	if v {
+		return "yes"
+	}
+	return "no"
+}
+
+func main() {}

--- a/skills/examples/timer/README.md
+++ b/skills/examples/timer/README.md
@@ -1,0 +1,30 @@
+# Timer Skill
+
+Reference countdown timer implemented as a WASM module. The skill listens for `skill.timer.start` and `skill.timer.cancel` subjects and publishes status updates and TTS prompts.
+
+## Build (TinyGo)
+
+```bash
+cd skills/examples/timer
+mkdir -p build
+tinygo build -o build/timer.wasm -target=wasi ./src
+```
+
+## Local smoke test
+
+The module logs through the host via `host_log`. You can emulate a timer request by passing JSON in the `LOQA_TIMER_REQUEST` environment variable when running the module with a WASI runtime (for example, `wasmtime`):
+
+```bash
+wasmtime run --env LOQA_TIMER_REQUEST='{"duration_ms":2000,"label":"tea"}' build/timer.wasm
+```
+
+The TinyGo entrypoint will pause for the requested duration and log start/complete messages.
+
+## Deploying into Loqa
+
+1. Validate the manifest:
+   ```bash
+   go run ./cmd/loqa-skill validate --file skill.yaml
+   ```
+2. Copy `skill.yaml` and the compiled `build/timer.wasm` into the skill search path configured for the runtime.
+3. Restart or reload the runtime so it discovers the updated artifacts.

--- a/skills/examples/timer/skill.yaml
+++ b/skills/examples/timer/skill.yaml
@@ -1,25 +1,25 @@
 metadata:
   name: timer
   version: 0.1.0
-  description: Basic timer skill
+  description: Simple countdown timer skill that announces when time elapses.
   author: Ambiware Labs
-  tags:
-    - timers
 runtime:
   mode: wasm
   module: build/timer.wasm
-  entrypoint: handle
+  entrypoint: run
   host_version: v1
 capabilities:
   bus:
-    publish:
-      - tts.request
     subscribe:
       - skill.timer.start
-  storage:
-    kv: true
+      - skill.timer.cancel
+    publish:
+      - tts.request
+      - skill.timer.status
   timers: true
 permissions:
   - event_store:read
+  - bus:publish
 surfaces:
   voice: true
+  automations: true

--- a/skills/examples/timer/src/main.go
+++ b/skills/examples/timer/src/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/ambiware-labs/loqa-core/skills/examples/internal/host"
+)
+
+// requestEnvelope models the expected payload for a timer start event.
+type requestEnvelope struct {
+	DurationMS int    `json:"duration_ms"`
+	Label      string `json:"label"`
+}
+
+//export run
+func run() {
+	host.Log("timer skill initialized")
+
+	data := os.Getenv("LOQA_TIMER_REQUEST")
+	if data == "" {
+		host.Log("no timer payload provided; set LOQA_TIMER_REQUEST to test locally")
+		return
+	}
+
+	var req requestEnvelope
+	if err := json.Unmarshal([]byte(data), &req); err != nil {
+		host.Log("failed to decode timer payload: " + err.Error())
+		return
+	}
+	if req.DurationMS <= 0 {
+		host.Log("missing or invalid duration_ms in request")
+		return
+	}
+
+	delay := time.Duration(req.DurationMS) * time.Millisecond
+	label := req.Label
+	if label == "" {
+		label = "timer"
+	}
+
+	host.Log(fmt.Sprintf("starting %s for %s", label, delay))
+	time.Sleep(delay)
+	host.Log(fmt.Sprintf("%s complete", label))
+}
+
+func main() {}


### PR DESCRIPTION
## Summary
- add WASM timer and smart-home reference skills with manifests and docs
- expose host log bridge in the skills runtime for TinyGo modules
- run TinyGo builds and manifest validation for examples in CI (and update docs)

## Testing
- go test ./...
- go run ./cmd/loqa-skill validate --file skills/examples/timer/skill.yaml
- go run ./cmd/loqa-skill validate --file skills/examples/smart-home/skill.yaml

Closes #27