### PR TITLE
Implement skills service with NATS integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ Skill packages declare metadata, runtime, and permissions in a `skill.yaml` mani
 go run ./cmd/loqa-skill validate --file skills/examples/timer/skill.yaml
 ```
 
+When `skills.enabled` is true in `config/example.yaml`, the runtime loads manifests from `skills.directory`, subscribes to declared NATS subjects, and invokes the corresponding WASM module for each event. Skills publish responses via the host API—`host.Publish` enforces both the `bus:publish` permission and the subjects enumerated in `capabilities.bus.publish`. All invocations and publish operations are recorded in the event-store audit log under the `skill:*` sessions configured by `skills.audit_privacy_scope`.
+
+See [`skills/AUTHORING_GUIDE.md`](skills/AUTHORING_GUIDE.md) for a step-by-step walkthrough on building TinyGo skills, defining manifests, and testing locally.
+
 ## Architecture
 
 Loqa is designed as a modular, distributed system that can scale across multiple local nodes:

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -26,6 +26,11 @@ node:
       tier: balanced
       attributes:
         modality: orchestration
+skills:
+  enabled: true
+  directory: ./skills
+  max_concurrency: 4
+  audit_privacy_scope: internal
 event_store:
   path: ./data/loqa-events.db
   retention_mode: session

--- a/internal/skills/runtime/runtime.go
+++ b/internal/skills/runtime/runtime.go
@@ -2,8 +2,10 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
+	"log/slog"
 	"os"
 
 	"github.com/ambiware-labs/loqa-core/internal/skills/manifest"
@@ -14,19 +16,21 @@ import (
 
 // Runtime wraps a wazero runtime for executing skill modules.
 type Runtime struct {
-	rt wazero.Runtime
+	rt   wazero.Runtime
+	host HostBindings
 }
 
 // New creates a new skill runtime using wazero.
-func New(ctx context.Context) (*Runtime, error) {
+func New(ctx context.Context, host HostBindings) (*Runtime, error) {
 	rt := wazero.NewRuntime(ctx)
-	if err := instantiateHostModule(ctx, rt); err != nil {
+	host = host.ensure()
+	if err := instantiateHostModule(ctx, rt, host); err != nil {
 		return nil, fmt.Errorf("instantiate host module: %w", err)
 	}
 	if _, err := wasi_snapshot_preview1.Instantiate(ctx, rt); err != nil {
 		return nil, fmt.Errorf("instantiate WASI: %w", err)
 	}
-	return &Runtime{rt: rt}, nil
+	return &Runtime{rt: rt, host: host}, nil
 }
 
 // Close releases resources held by the runtime.
@@ -64,7 +68,7 @@ func (s *Skill) Close(ctx context.Context) error {
 }
 
 // Load compiles and instantiates a skill from a manifest.
-func (r *Runtime) Load(ctx context.Context, m manifest.Manifest) (*Skill, error) {
+func (r *Runtime) Load(ctx context.Context, m manifest.Manifest, env map[string]string) (*Skill, error) {
 	if r == nil || r.rt == nil {
 		return nil, fmt.Errorf("runtime not initialized")
 	}
@@ -79,7 +83,11 @@ func (r *Runtime) Load(ctx context.Context, m manifest.Manifest) (*Skill, error)
 	if err != nil {
 		return nil, fmt.Errorf("compile module: %w", err)
 	}
-	module, err := r.rt.InstantiateModule(ctx, compiled, wazero.NewModuleConfig())
+	moduleConfig := wazero.NewModuleConfig()
+	for k, v := range env {
+		moduleConfig = moduleConfig.WithEnv(k, v)
+	}
+	module, err := r.rt.InstantiateModule(ctx, compiled, moduleConfig)
 	if err != nil {
 		compiled.Close(ctx)
 		return nil, fmt.Errorf("instantiate module: %w", err)
@@ -107,8 +115,14 @@ func (s *Skill) Invoke(ctx context.Context) error {
 	return err
 }
 
-func instantiateHostModule(ctx context.Context, rt wazero.Runtime) error {
-	logger := log.New(os.Stdout, "[skill] ", 0)
+func instantiateHostModule(ctx context.Context, rt wazero.Runtime, host HostBindings) error {
+	logger := host.Logger
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(os.Stdout, nil))
+	}
+	printfLogger := log.New(os.Stdout, "[skill] ", 0)
+	binding := host.ensure()
+
 	builder := rt.NewHostModuleBuilder("env")
 	hostLogFn := api.GoModuleFunc(func(_ context.Context, mod api.Module, stack []uint64) {
 		if len(stack) < 2 {
@@ -121,19 +135,112 @@ func instantiateHostModule(ctx context.Context, rt wazero.Runtime) error {
 		}
 		mem := mod.Memory()
 		if mem == nil {
-			logger.Printf("host_log: module has no memory (ptr=%d len=%d)", ptr, length)
+			printfLogger.Printf("host_log: module has no memory (ptr=%d len=%d)", ptr, length)
 			return
 		}
 		data, ok := mem.Read(ptr, length)
 		if !ok {
-			logger.Printf("host_log: unable to read memory (ptr=%d len=%d)", ptr, length)
+			printfLogger.Printf("host_log: unable to read memory (ptr=%d len=%d)", ptr, length)
 			return
 		}
-		logger.Print(string(data))
+		msg := string(data)
+		logger.Info("skill log", slog.String("message", msg))
+		if binding.RecordAudit != nil {
+			binding.RecordAudit(AuditEvent{Type: "skill.log", Data: map[string]any{"message": msg}})
+		}
 	})
 	builder.NewFunctionBuilder().
 		WithGoModuleFunction(hostLogFn, []api.ValueType{api.ValueTypeI32, api.ValueTypeI32}, nil).
+		WithName("host_log").
 		Export("host_log")
+
+	hostPublishFn := api.GoModuleFunc(func(_ context.Context, mod api.Module, stack []uint64) {
+		if len(stack) < 4 {
+			return
+		}
+		subjectPtr := api.DecodeU32(stack[0])
+		subjectLen := api.DecodeU32(stack[1])
+		payloadPtr := api.DecodeU32(stack[2])
+		payloadLen := api.DecodeU32(stack[3])
+
+		mem := mod.Memory()
+		if mem == nil {
+			stack[0] = api.EncodeI32(int32(PublishErrRuntime))
+			return
+		}
+		subjectBytes, ok := mem.Read(subjectPtr, subjectLen)
+		if !ok {
+			stack[0] = api.EncodeI32(int32(PublishErrRuntime))
+			return
+		}
+		subject := string(subjectBytes)
+		if binding.AllowPublish != nil {
+			if err := binding.AllowPublish(subject); err != nil {
+				stack[0] = api.EncodeI32(int32(PublishErrNotAllowed))
+				logger.Warn("skill publish blocked", slog.String("subject", subject), slog.String("error", err.Error()))
+				return
+			}
+		}
+		var payload []byte
+		if payloadLen > 0 {
+			if data, ok := mem.Read(payloadPtr, payloadLen); ok {
+				payload = append([]byte(nil), data...)
+			} else {
+				stack[0] = api.EncodeI32(int32(PublishErrRuntime))
+				return
+			}
+		}
+		if binding.Publish == nil {
+			stack[0] = api.EncodeI32(int32(PublishErrRuntime))
+			return
+		}
+		if err := binding.Publish(subject, payload); err != nil {
+			stack[0] = api.EncodeI32(int32(PublishErrRuntime))
+			logger.Error("skill publish failed", slog.String("subject", subject), slog.String("error", err.Error()))
+			return
+		}
+		if binding.RecordAudit != nil {
+			binding.RecordAudit(AuditEvent{Type: "skill.publish", Data: map[string]any{
+				"subject":       subject,
+				"payload_bytes": payloadLen,
+			}})
+		}
+		stack[0] = api.EncodeI32(int32(PublishOK))
+	})
+	builder.NewFunctionBuilder().
+		WithGoModuleFunction(hostPublishFn, []api.ValueType{api.ValueTypeI32, api.ValueTypeI32, api.ValueTypeI32, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).
+		WithName("host_publish").
+		WithResultNames("code").
+		Export("host_publish")
+
 	_, err := builder.Instantiate(ctx)
 	return err
+}
+
+const (
+	PublishOK            = 0
+	PublishErrNotAllowed = 1
+	PublishErrRuntime    = 2
+)
+
+type HostBindings struct {
+	Logger       *slog.Logger
+	AllowPublish func(subject string) error
+	Publish      func(subject string, payload []byte) error
+	RecordAudit  func(event AuditEvent)
+}
+
+func (h HostBindings) ensure() HostBindings {
+	if h.AllowPublish == nil {
+		h.AllowPublish = func(string) error { return errors.New("publish disallowed") }
+	}
+	if h.Publish == nil {
+		h.Publish = func(string, []byte) error { return errors.New("publish unsupported") }
+	}
+	return h
+}
+
+type AuditEvent struct {
+	Type string
+	Data map[string]any
 }

--- a/internal/skills/runtime/runtime_test.go
+++ b/internal/skills/runtime/runtime_test.go
@@ -31,7 +31,7 @@ permissions:
 
 func TestRuntimeLoadMissingFile(t *testing.T) {
 	ctx := context.Background()
-	rt, err := runtime.New(ctx)
+	rt, err := runtime.New(ctx, runtime.HostBindings{})
 	if err != nil {
 		t.Fatalf("create runtime: %v", err)
 	}
@@ -48,7 +48,7 @@ func TestRuntimeLoadMissingFile(t *testing.T) {
 		t.Fatalf("load manifest: %v", err)
 	}
 
-	if _, err := rt.Load(ctx, mf); err == nil {
+	if _, err := rt.Load(ctx, mf, map[string]string{}); err == nil {
 		t.Fatalf("expected error for missing module")
 	}
 }

--- a/internal/skills/service/service.go
+++ b/internal/skills/service/service.go
@@ -1,0 +1,330 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ambiware-labs/loqa-core/internal/bus"
+	"github.com/ambiware-labs/loqa-core/internal/config"
+	"github.com/ambiware-labs/loqa-core/internal/eventstore"
+	manifestpkg "github.com/ambiware-labs/loqa-core/internal/skills/manifest"
+	skillrt "github.com/ambiware-labs/loqa-core/internal/skills/runtime"
+	"github.com/google/uuid"
+	"github.com/nats-io/nats.go"
+)
+
+// Service manages lifecycle and execution of WASM skills.
+type Service struct {
+	cfg    config.SkillsConfig
+	log    *slog.Logger
+	bus    *bus.Client
+	store  *eventstore.Store
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+	sema   chan struct{}
+
+	mu     sync.RWMutex
+	skills map[string]*binding
+	subs   []*nats.Subscription
+
+	healthy bool
+}
+
+type binding struct {
+	manifest      manifestpkg.Manifest
+	manifestPath  string
+	modulePath    string
+	directory     string
+	publishSet    map[string]struct{}
+	subscribeList []string
+	permissions   map[string]struct{}
+	sessionID     string
+}
+
+// New creates the skills service. When cfg.Enabled is false, nil is returned.
+func New(ctx context.Context, cfg config.SkillsConfig, busClient *bus.Client, store *eventstore.Store, logger *slog.Logger) (*Service, error) {
+	if !cfg.Enabled {
+		return nil, nil
+	}
+	if busClient == nil {
+		return nil, errors.New("skills service requires bus client")
+	}
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(os.Stdout, nil))
+	}
+	if cfg.Concurrency <= 0 {
+		cfg.Concurrency = 1
+	}
+	cctx, cancel := context.WithCancel(ctx)
+	svc := &Service{
+		cfg:    cfg,
+		log:    logger.With(slog.String("component", "skills.service")),
+		bus:    busClient,
+		store:  store,
+		ctx:    cctx,
+		cancel: cancel,
+		sema:   make(chan struct{}, cfg.Concurrency),
+		skills: make(map[string]*binding),
+	}
+	if err := svc.loadSkills(); err != nil {
+		cancel()
+		return nil, err
+	}
+	if err := svc.registerSubscriptions(); err != nil {
+		svc.Close()
+		return nil, err
+	}
+	svc.healthy = true
+	return svc, nil
+}
+
+// Close terminates subscriptions and waits for in-flight executions.
+func (s *Service) Close() {
+	s.cancel()
+	s.mu.Lock()
+	for _, sub := range s.subs {
+		if sub != nil {
+			_ = sub.Drain()
+		}
+	}
+	s.subs = nil
+	s.mu.Unlock()
+	s.wg.Wait()
+}
+
+// Healthy reports whether the service is running with active subscriptions.
+func (s *Service) Healthy() bool {
+	return s != nil && s.healthy
+}
+
+func (s *Service) loadSkills() error {
+	root := s.cfg.Directory
+	if root == "" {
+		return errors.New("skills directory not configured")
+	}
+	entries := 0
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if strings.EqualFold(d.Name(), "skill.yaml") {
+			entries++
+			if err := s.addSkill(path); err != nil {
+				s.log.Error("failed to load skill", slog.String("path", path), slog.String("error", err.Error()))
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if len(s.skills) == 0 {
+		s.log.Warn("no skills discovered", slog.String("directory", root))
+	} else {
+		s.log.Info("skills discovered", slog.Int("count", len(s.skills)))
+	}
+	return nil
+}
+
+func (s *Service) addSkill(manifestPath string) error {
+	mf, err := manifestpkg.Load(manifestPath)
+	if err != nil {
+		return fmt.Errorf("load manifest: %w", err)
+	}
+	if err := manifestpkg.Validate(mf); err != nil {
+		return fmt.Errorf("validate manifest: %w", err)
+	}
+	name := mf.Metadata.Name
+	if name == "" {
+		return errors.New("manifest missing metadata.name")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.skills[name]; exists {
+		return fmt.Errorf("duplicate skill name %s", name)
+	}
+
+	baseDir := filepath.Dir(manifestPath)
+	modulePath := mf.Runtime.Module
+	if !filepath.IsAbs(modulePath) {
+		modulePath = filepath.Join(baseDir, modulePath)
+	}
+
+	publishSet := make(map[string]struct{}, len(mf.Capabilities.Bus.Publish))
+	for _, subj := range mf.Capabilities.Bus.Publish {
+		publishSet[subj] = struct{}{}
+	}
+	permSet := make(map[string]struct{}, len(mf.Permissions))
+	for _, perm := range mf.Permissions {
+		permSet[perm] = struct{}{}
+	}
+
+	binding := &binding{
+		manifest:      mf,
+		manifestPath:  manifestPath,
+		modulePath:    modulePath,
+		directory:     baseDir,
+		publishSet:    publishSet,
+		subscribeList: append([]string(nil), mf.Capabilities.Bus.Subscribe...),
+		permissions:   permSet,
+		sessionID:     fmt.Sprintf("skill:%s", name),
+	}
+
+	s.skills[name] = binding
+	return nil
+}
+
+func (s *Service) registerSubscriptions() error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, binding := range s.skills {
+		for _, subject := range binding.subscribeList {
+			subject := subject
+			handler := s.makeHandler(binding)
+			sub, err := s.bus.Conn().Subscribe(subject, handler)
+			if err != nil {
+				return fmt.Errorf("subscribe %s: %w", subject, err)
+			}
+			s.subs = append(s.subs, sub)
+			s.log.Info("skill subscribed", slog.String("skill", binding.manifest.Metadata.Name), slog.String("subject", subject))
+		}
+	}
+	return nil
+}
+
+func (s *Service) makeHandler(binding *binding) nats.MsgHandler {
+	return func(msg *nats.Msg) {
+		select {
+		case <-s.ctx.Done():
+			return
+		default:
+		}
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			s.sema <- struct{}{}
+			defer func() { <-s.sema }()
+			if err := s.invoke(binding, msg); err != nil {
+				s.log.Error("skill invocation failed", slog.String("skill", binding.manifest.Metadata.Name), slog.String("subject", msg.Subject), slog.String("error", err.Error()))
+			}
+		}()
+	}
+}
+
+func (s *Service) invoke(binding *binding, msg *nats.Msg) error {
+	ctx, cancel := context.WithTimeout(s.ctx, 30*time.Second)
+	defer cancel()
+
+	invocationID := uuid.NewString()
+	env := map[string]string{
+		"LOQA_SKILL_NAME":      binding.manifest.Metadata.Name,
+		"LOQA_EVENT_SUBJECT":   msg.Subject,
+		"LOQA_EVENT_PAYLOAD":   string(msg.Data),
+		"LOQA_INVOCATION_ID":   invocationID,
+		"LOQA_SKILL_DIRECTORY": binding.directory,
+	}
+	if msg.Reply != "" {
+		env["LOQA_EVENT_REPLY"] = msg.Reply
+	}
+
+	hostLogger := s.log.With(
+		slog.String("skill", binding.manifest.Metadata.Name),
+		slog.String("invocation_id", invocationID),
+	)
+
+	hostBindings := skillrt.HostBindings{
+		Logger: hostLogger,
+		AllowPublish: func(subject string) error {
+			if _, ok := binding.permissions["bus:publish"]; !ok {
+				return fmt.Errorf("missing permission bus:publish")
+			}
+			if _, ok := binding.publishSet[subject]; !ok {
+				return fmt.Errorf("subject %s not declared in manifest", subject)
+			}
+			return nil
+		},
+		Publish: func(subject string, payload []byte) error {
+			return s.bus.Conn().Publish(subject, payload)
+		},
+		RecordAudit: func(event skillrt.AuditEvent) {
+			s.appendAudit(binding, invocationID, event)
+		},
+	}
+
+	runtime, err := skillrt.New(ctx, hostBindings)
+	if err != nil {
+		return fmt.Errorf("init runtime: %w", err)
+	}
+	defer runtime.Close(ctx)
+
+	mf := binding.manifest
+	mf.Runtime.Module = binding.modulePath
+
+	skill, err := runtime.Load(ctx, mf, env)
+	if err != nil {
+		return fmt.Errorf("load skill: %w", err)
+	}
+	defer skill.Close(ctx)
+
+	start := time.Now()
+	s.appendAudit(binding, invocationID, skillrt.AuditEvent{Type: "skill.invoke.start", Data: map[string]any{
+		"subject": msg.Subject,
+	}})
+
+	if err := skill.Invoke(ctx); err != nil {
+		s.appendAudit(binding, invocationID, skillrt.AuditEvent{Type: "skill.invoke.error", Data: map[string]any{
+			"error": err.Error(),
+		}})
+		return err
+	}
+
+	s.appendAudit(binding, invocationID, skillrt.AuditEvent{Type: "skill.invoke.complete", Data: map[string]any{
+		"duration_ms": time.Since(start).Milliseconds(),
+	}})
+	return nil
+}
+
+func (s *Service) appendAudit(binding *binding, invocationID string, event skillrt.AuditEvent) {
+	if s.store == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_ = s.store.AppendSession(ctx, binding.sessionID, binding.manifest.Metadata.Name, s.cfg.AuditPrivacy)
+	payload := map[string]any{
+		"invocation_id": invocationID,
+		"skill":         binding.manifest.Metadata.Name,
+	}
+	for k, v := range event.Data {
+		payload[k] = v
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		s.log.Warn("failed to marshal audit event", slog.String("error", err.Error()))
+		return
+	}
+	evt := eventstore.Event{
+		SessionID: binding.sessionID,
+		ActorID:   binding.manifest.Metadata.Name,
+		Type:      event.Type,
+		Payload:   data,
+		Privacy:   s.cfg.AuditPrivacy,
+	}
+	if err := s.store.AppendEvent(ctx, evt); err != nil {
+		s.log.Warn("failed to append audit event", slog.String("error", err.Error()))
+	}
+}

--- a/skills/AUTHORING_GUIDE.md
+++ b/skills/AUTHORING_GUIDE.md
@@ -1,0 +1,85 @@
+# Loqa Skill Authoring Guide
+
+This guide walks through building, packaging, and registering third-party skills for the Loqa runtime.
+
+## 1. Project layout
+
+Each skill lives in its own directory containing:
+
+- `skill.yaml` – manifest describing metadata, runtime module path, capabilities, and permissions.
+- `src/` – TinyGo sources compiled to a WASI-compatible WASM module.
+- Optional assets or configuration files referenced by the manifest (for example, static prompts).
+
+Example tree:
+
+```
+skills/
+  my-skill/
+    skill.yaml
+    src/
+      main.go
+```
+
+## 2. Manifest essentials
+
+`skill.yaml` is validated with `go run ./cmd/loqa-skill validate --file skill.yaml`. Required sections:
+
+- `metadata` – name, version, description, and author.
+- `runtime` – currently `mode: wasm`, relative path to the compiled module, entrypoint function, and host ABI version (`v1`).
+- `capabilities.bus.publish` and `.subscribe` – NATS subjects this skill will interact with.
+- `permissions` – opt-in host powers such as `bus:publish` or `event_store:read`.
+
+The runtime enforces both permissions and declared subjects at execution time; attempts to publish a subject not listed in the manifest are rejected.
+
+## 3. Building the WASM module
+
+- Install TinyGo `0.39.0` or newer.
+- Build with the WASI target:
+
+  ```bash
+  tinygo build -o build/my-skill.wasm -target=wasi ./src
+  ```
+
+  The CI pipeline uses the same command, so keep sources and manifests in sync.
+
+## 4. Runtime environment variables
+
+The runtime injects context for each invocation via environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `LOQA_EVENT_SUBJECT` | NATS subject that triggered the invocation |
+| `LOQA_EVENT_PAYLOAD` | Raw payload bytes (UTF-8 JSON by convention) |
+| `LOQA_EVENT_REPLY` | Optional reply subject |
+| `LOQA_INVOCATION_ID` | Unique identifier for the invocation |
+| `LOQA_SKILL_DIRECTORY` | Absolute path to the skill directory |
+
+Use these to deserialize requests and locate assets.
+
+## 5. Host APIs
+
+The shared helper in `skills/examples/internal/host` exposes:
+
+- `host.Log(string)` – writes to runtime logs and the audit trail.
+- `host.Publish(subject string, payload []byte) bool` – publishes to NATS (requires `bus:publish` and a declared subject).
+
+Future ABI versions will add storage and HTTP helpers; design manifests with explicit permissions so skills remain sandboxed.
+
+## 6. Deployment steps
+
+1. Compile the WASM module and validate the manifest.
+2. Copy both `skill.yaml` and the compiled module into the runtime's skill directory (default `./skills`).
+3. Restart or hot-reload the runtime. The skills service watches the directory on startup and subscribes to declared subjects.
+4. Emit test events on the declared subjects to verify behaviour. Watch telemetry and the event store audit log for activity.
+
+## 7. Observability & audit
+
+Each invocation generates audit events in the local event store, including start, completion, and publish activity. Use these logs to troubleshoot permission failures or unexpected outcomes.
+
+## 8. Next steps
+
+- Review the reference implementations in `skills/examples` for patterns.
+- Contribute new capabilities via pull requests or RFCs in `loqa-meta`.
+- Share reusable skills with the community and tag manifests with descriptive metadata for discovery.
+
+Happy building!

--- a/skills/README.md
+++ b/skills/README.md
@@ -28,8 +28,10 @@ Repeat the same steps for other examples like `smart-home`.
 
 Both examples accept environment variables so you can simulate inbound events before integrating with Loqa:
 
-- `LOQA_TIMER_REQUEST` drives the timer countdown example.
-- `LOQA_SMART_HOME_INTENT` plus optional Home Assistant credentials drive the smart-home bridge.
+- `LOQA_EVENT_SUBJECT` and `LOQA_EVENT_PAYLOAD` emulate the NATS message that triggered the invocation.
+- Optional context such as `LOQA_EVENT_REPLY` and `LOQA_INVOCATION_ID` are provided automatically by the runtime.
+
+The shared TinyGo helper exposes `host.Log(msg string)` and `host.Publish(subject string, payload []byte)` for communicating with the host. Publishing requires the manifest to declare `bus:publish` permission and list allowed subjects under `capabilities.bus.publish`.
 
 See the README inside each example directory for precise commands.
 

--- a/skills/examples/internal/host/host.go
+++ b/skills/examples/internal/host/host.go
@@ -13,5 +13,24 @@ func Log(msg string) {
 	hostLog(unsafe.Pointer(&b[0]), uint32(len(b)))
 }
 
+// Publish sends a message to the host bus if permitted by the manifest.
+func Publish(subject string, payload []byte) bool {
+	if len(subject) == 0 {
+		return false
+	}
+	subjectBuf := []byte(subject)
+	var payloadPtr unsafe.Pointer
+	var payloadLen uint32
+	if len(payload) > 0 {
+		payloadPtr = unsafe.Pointer(&payload[0])
+		payloadLen = uint32(len(payload))
+	}
+	code := hostPublish(unsafe.Pointer(&subjectBuf[0]), uint32(len(subjectBuf)), payloadPtr, payloadLen)
+	return code == 0
+}
+
 //go:wasmimport env host_log
 func hostLog(ptr unsafe.Pointer, length uint32)
+
+//go:wasmimport env host_publish
+func hostPublish(subjectPtr unsafe.Pointer, subjectLen uint32, payloadPtr unsafe.Pointer, payloadLen uint32) uint32

--- a/skills/examples/internal/host/host_stub.go
+++ b/skills/examples/internal/host/host_stub.go
@@ -4,3 +4,6 @@ package host
 
 // Log is a no-op stub for non-wasm builds so that `go test` succeeds.
 func Log(string) {}
+
+// Publish is a no-op stub for non-wasm builds.
+func Publish(string, []byte) bool { return false }

--- a/skills/examples/smart-home/README.md
+++ b/skills/examples/smart-home/README.md
@@ -18,7 +18,8 @@ The module reads configuration from environment variables so you can experiment 
 wasmtime run \
   --env HOMEASSISTANT_URL="http://localhost:8123" \
   --env HOMEASSISTANT_TOKEN="demo-token" \
-  --env LOQA_SMART_HOME_INTENT='{"room":"kitchen","device":"light.kitchen","action":"turn_on","payload":"brightness=80"}' \
+  --env LOQA_EVENT_SUBJECT="skill.home.command" \
+  --env LOQA_EVENT_PAYLOAD='{"room":"kitchen","device":"light.kitchen","action":"turn_on","payload":"brightness=80"}' \
   build/smart-home.wasm
 ```
 

--- a/skills/examples/timer/README.md
+++ b/skills/examples/timer/README.md
@@ -12,10 +12,13 @@ tinygo build -o build/timer.wasm -target=wasi ./src
 
 ## Local smoke test
 
-The module logs through the host via `host_log`. You can emulate a timer request by passing JSON in the `LOQA_TIMER_REQUEST` environment variable when running the module with a WASI runtime (for example, `wasmtime`):
+The module logs through the host via `host_log`. You can emulate a timer request by passing JSON in the `LOQA_EVENT_PAYLOAD` environment variable and setting the subject the same way Loqa would:
 
 ```bash
-wasmtime run --env LOQA_TIMER_REQUEST='{"duration_ms":2000,"label":"tea"}' build/timer.wasm
+wasmtime run \
+  --env LOQA_EVENT_SUBJECT="skill.timer.start" \
+  --env LOQA_EVENT_PAYLOAD='{"duration_ms":2000,"label":"tea"}' \
+  build/timer.wasm
 ```
 
 The TinyGo entrypoint will pause for the requested duration and log start/complete messages.


### PR DESCRIPTION
## Summary
- add configurable skills service that loads manifests, subscribes to NATS, and invokes WASM skills with audit logging
- extend WASM host ABI with publish support and enforce manifest permissions
- refresh reference skills, docs, and TinyGo toolchain guidance (including authoring guide)

## Testing
- go test ./...
