### PR TITLE
Add getting started guide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 FILES := $(shell git ls-files '*.go')
 
-.PHONY: fmt fmt-check vet test skills lint ci
+.PHONY: fmt fmt-check vet test skills run lint ci
 
 fmt:
 	@if [ -n "$(FILES)" ]; then gofmt -w $(FILES); fi
@@ -26,6 +26,9 @@ skills:
 	cd skills/examples/smart-home && mkdir -p build && tinygo build -o build/smart-home.wasm -target=wasi ./src
 	go run ./cmd/loqa-skill validate --file skills/examples/timer/skill.yaml
 	go run ./cmd/loqa-skill validate --file skills/examples/smart-home/skill.yaml
+
+run:
+	go run ./cmd/loqad --config ./config/example.yaml
 
 lint: fmt-check vet
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ Loqa Core contains the foundational components for building and running a distri
 
 ## Getting Started
 
-Install prerequisites (Go 1.21+). Then:
+- **Read the Quickstart:** Follow the step-by-step guide in [`docs/GETTING_STARTED.md`](docs/GETTING_STARTED.md) to install prerequisites, build the sample skills, and publish your first events.
+- **Launch the runtime quickly:**
 
-```bash
-go run ./cmd/loqad --config ./config/example.yaml
-```
+  ```bash
+  make skills   # builds TinyGo examples and validates manifests
+  make run      # runs go run ./cmd/loqad --config ./config/example.yaml
+  ```
 
 If no config file is supplied the runtime loads defaults and respects the following environment overrides:
 


### PR DESCRIPTION
## Summary
- add docs/GETTING_STARTED.md with step-by-step quickstart instructions
- add make targets (skills, run, ci) reference to simplify local workflows
- update README to link to the new guide

## Testing
- make skills
- make run (manual verification)
