### PR TITLE
Add nightly build bundles and workflows

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,104 @@
+name: Nightly builds
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.x'
+
+      - name: Set up TinyGo
+        uses: acifani/setup-tinygo@v2
+        with:
+          tinygo-version: '0.39.0'
+
+      - name: Determine build metadata
+        id: meta
+        run: |
+          timestamp=$(date -u +"%Y%m%d")
+          echo "version=nightly-${timestamp}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify toolchains
+        run: |
+          go version
+          tinygo version
+
+      - name: Run unit tests
+        run: go test ./...
+
+      - name: Build reference skills
+        run: make skills
+
+      - name: Assemble bundle
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          BUNDLE="loqa-core_${VERSION}_${GOOS}_${GOARCH}"
+          ROOT="dist/${BUNDLE}"
+          BIN_DIR="${ROOT}/bin"
+
+          rm -rf dist
+          mkdir -p "$BIN_DIR" "${ROOT}/config" "${ROOT}/docs" "${ROOT}/skills"
+
+          EXT=""
+          if [ "$GOOS" = "windows" ]; then
+            EXT=".exe"
+          fi
+
+          echo "Building loqad ${VERSION} for ${GOOS}/${GOARCH}"
+          CGO_ENABLED=0 GOOS=$GOOS GOARCH=$GOARCH go build \
+            -ldflags "-s -w -X main.version=${VERSION}" \
+            -o "${BIN_DIR}/loqad${EXT}" \
+            ./cmd/loqad
+
+          echo "Building loqa-skill ${VERSION} for ${GOOS}/${GOARCH}"
+          CGO_ENABLED=0 GOOS=$GOOS GOARCH=$GOARCH go build \
+            -ldflags "-s -w -X main.version=${VERSION}" \
+            -o "${BIN_DIR}/loqa-skill${EXT}" \
+            ./cmd/loqa-skill
+
+          cp LICENSE "${ROOT}/"
+          cp README.md "${ROOT}/"
+          cp docs/GETTING_STARTED.md "${ROOT}/docs/GETTING_STARTED.md"
+          cp config/example.yaml "${ROOT}/config/example.yaml"
+
+          mkdir -p "${ROOT}/skills/examples"
+          cp -R skills/examples/timer "${ROOT}/skills/examples/timer"
+          cp -R skills/examples/smart-home "${ROOT}/skills/examples/smart-home"
+
+          tar -C dist -czf "dist/${BUNDLE}.tar.gz" "${BUNDLE}"
+          sha256sum "dist/${BUNDLE}.tar.gz" | sed 's#  dist/#  #' > "dist/${BUNDLE}.tar.gz.sha256"
+
+      - name: Upload bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.meta.outputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: |
+            dist/loqa-core_${{ steps.meta.outputs.version }}_${{ matrix.goos }}_${{ matrix.goarch }}.tar.gz
+            dist/loqa-core_${{ steps.meta.outputs.version }}_${{ matrix.goos }}_${{ matrix.goarch }}.tar.gz.sha256
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,127 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version label for snapshot builds (optional)"
+        required: false
+        default: ""
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24.x"
+
+      - name: Set up TinyGo
+        uses: acifani/setup-tinygo@v2
+        with:
+          tinygo-version: "0.39.0"
+
+      - name: Build reference skills
+        run: make skills
+
+      - name: Run unit tests
+        run: go test ./...
+
+      - name: Determine version
+        id: meta
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          elif [[ -n "${{ github.event.inputs.version }}" ]]; then
+            echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=snapshot-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build bundle
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          rm -rf dist
+
+          BUNDLE_NAME="loqa-core_${VERSION}_${GOOS}_${GOARCH}"
+          ROOT_DIR="dist/${BUNDLE_NAME}"
+          BIN_DIR="${ROOT_DIR}/bin"
+          mkdir -p "${BIN_DIR}" "${ROOT_DIR}/config" "${ROOT_DIR}/docs" "${ROOT_DIR}/skills"
+
+          EXT=""
+          if [ "$GOOS" = "windows" ]; then
+            EXT=".exe"
+          fi
+
+          echo "Building loqad ${VERSION} for ${GOOS}/${GOARCH}"
+          CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go build \
+            -ldflags "-s -w -X main.version=${VERSION}" \
+            -o "${BIN_DIR}/loqad${EXT}" \
+            ./cmd/loqad
+
+          echo "Building loqa-skill ${VERSION} for ${GOOS}/${GOARCH}"
+          CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go build \
+            -ldflags "-s -w -X main.version=${VERSION}" \
+            -o "${BIN_DIR}/loqa-skill${EXT}" \
+            ./cmd/loqa-skill
+
+          cp LICENSE "${ROOT_DIR}/"
+          cp README.md "${ROOT_DIR}/"
+          cp docs/GETTING_STARTED.md "${ROOT_DIR}/docs/GETTING_STARTED.md"
+          cp config/example.yaml "${ROOT_DIR}/config/example.yaml"
+
+          mkdir -p "${ROOT_DIR}/skills/examples"
+          cp -R skills/examples/timer "${ROOT_DIR}/skills/examples/timer"
+          cp -R skills/examples/smart-home "${ROOT_DIR}/skills/examples/smart-home"
+
+          tar -C dist -czf "dist/${BUNDLE_NAME}.tar.gz" "${BUNDLE_NAME}"
+          sha256sum "dist/${BUNDLE_NAME}.tar.gz" | sed 's#  dist/#  #' > "dist/${BUNDLE_NAME}.tar.gz.sha256"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.meta.outputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: |
+            dist/loqa-core_${{ steps.meta.outputs.version }}_${{ matrix.goos }}_${{ matrix.goarch }}.tar.gz
+            dist/loqa-core_${{ steps.meta.outputs.version }}_${{ matrix.goos }}_${{ matrix.goarch }}.tar.gz.sha256
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref_type == 'tag'
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ Loqa Core contains the foundational components for building and running a distri
 - **Documentation**: Technical docs and API references
 - **Proto Schemas**: Protocol definitions for inter-service communication
 
+## Downloads
+
+- **Nightly snapshots:** Every day the [Nightly builds](https://github.com/ambiware-labs/loqa-core/actions/workflows/nightly.yml) workflow publishes artifacts that contain precompiled `loqad`, `loqa-skill`, sample configs, docs, and the TinyGo example skill packages. Download the archive that matches your platform (e.g., `loqa-core_nightly-YYYYMMDD_linux_amd64.tar.gz`), verify it with the accompanying `.sha256`, and extract it with `tar -xzf`.
+- **Tagged releases:** Pushing a `v*` tag produces versioned bundles via the [Release workflow](https://github.com/ambiware-labs/loqa-core/actions/workflows/release.yml). These are attached automatically to the corresponding GitHub Release page.
+
 ## Getting Started
 
 - **Read the Quickstart:** Follow the step-by-step guide in [`docs/GETTING_STARTED.md`](docs/GETTING_STARTED.md) to install prerequisites, build the sample skills, and publish your first events.

--- a/cmd/loqa-skill/main.go
+++ b/cmd/loqa-skill/main.go
@@ -8,13 +8,15 @@ import (
 	"github.com/ambiware-labs/loqa-core/internal/skills/manifest"
 )
 
+var version = "0.1.0-dev"
+
 func main() {
 	var manifestPath string
 	validateCmd := flag.NewFlagSet("validate", flag.ExitOnError)
 	validateCmd.StringVar(&manifestPath, "file", "skill.yaml", "Path to skill manifest")
 
 	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stderr, "expected 'validate'")
+		fmt.Fprintln(os.Stderr, "expected 'validate' or 'version'")
 		os.Exit(2)
 	}
 
@@ -26,6 +28,8 @@ func main() {
 			os.Exit(1)
 		}
 		fmt.Println("manifest valid")
+	case "version":
+		fmt.Println(version)
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command %q\n", os.Args[1])
 		os.Exit(2)

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -13,6 +13,30 @@ Welcome! This guide walks you through running the Loqa runtime locally with the 
 
 > **Tip:** On macOS or Linux, you can use Homebrew: `brew install go tinygo nats-io/nats/nats`.
 
+### Optional: Download a nightly bundle
+
+If you want to skip building the binaries manually, grab the latest snapshot artifact:
+
+1. Visit the [Nightly builds workflow](https://github.com/ambiware-labs/loqa-core/actions/workflows/nightly.yml) and open the most recent successful run.
+2. Download the archive that matches your platform, for example `loqa-core_nightly-YYYYMMDD_linux_amd64.tar.gz`.
+3. (Recommended) Validate the checksum with `shasum -a 256 -c loqa-core_nightly-YYYYMMDD_linux_amd64.tar.gz.sha256`.
+4. Extract the bundle and add the binaries to your `PATH`:
+
+   ```bash
+   tar -xzf loqa-core_nightly-YYYYMMDD_linux_amd64.tar.gz
+   export PATH="$PWD/loqa-core_nightly-YYYYMMDD_linux_amd64/bin:$PATH"
+   ```
+
+You can perform the same download via the GitHub CLI:
+
+```bash
+gh run download \
+  --repo ambiware-labs/loqa-core \
+  --workflow nightly.yml \
+  --latest \
+  --name nightly-YYYYMMDD-linux-amd64
+```
+
 ## 1. Start NATS
 
 Loqa currently assumes a local NATS server with JetStream enabled. The quickest way to launch one is with Docker:


### PR DESCRIPTION
## Summary
- add release workflow that packages multi-arch bundles with docs and sample skills
- schedule nightly workflow to publish snapshot artifacts with checksums
- expose loqa-skill CLI version flag and document how to download the bundles

## Testing
- go test ./...
